### PR TITLE
Migrate current Python SDK documentation content

### DIFF
--- a/docs/sdks/python/concepts.md
+++ b/docs/sdks/python/concepts.md
@@ -1,0 +1,25 @@
+---
+description: Must-knows for working with the Python SDK
+---
+
+# Concepts
+
+## SDK Glossary
+
+| Name      | Description |
+| :-------- | :---------- |
+| Device  | Any physical device supplied with a SIM that obtains connectivity. It's important not to mix up the terms 'Device' and 'Endpoint.' A device is a superset of the endpoint and SIM acting as a whole. [Learn more about devices](https://support.emnify.com/hc/en-us/sections/115000981005-Device-Configuration).  |
+| Device Status  | Primary way to control connectivity. It can be either **Enabled** or **Disabled**. When **Enabled**, a device that has a SIM assigned can go online. On the other hand, when **Disabled**, the device doesn't get any service.  |
+| SIM  | Represents a physical or eSIM issued by emnify. [Learn more about SIM cards](https://support.emnify.com/hc/en-us/sections/360000642374-SIM-cards).  |
+| SIM Status  | Status of the SIM's phase in the [SIM lifecycle](https://www.emnify.com/blog/sim-lifecycle-management). When using the SDK, avoid changing the SIM status directly. Instead, change it using the device status.  |
+| Tariff Profile  | Controls where and how your devices have coverage. Referred to as **Coverage Policy** in the Enterprise Portal. [Learn more about tariff profiles](https://cdn.emnify.net/api/doc/tariff-profile.html).  |
+| Service Profile  | Defines available services (e.g., SMS, 4G, etc.) and traffic limits for a device. Referred to as **Service Policy** in the Enterprise Portal. [Learn more about service profiles](https://cdn.emnify.net/api/doc/service-profile.html).  |
+| Blacklist Operators  | Method that allows you to restrict device connectivity to a specific operator or group of operators.  |
+| Operator  | Underlying mobile network operator (MNO) used to provide connectivity. Explore operator coverage by country and region on [our pricing page](https://www.emnify.com/pricing).  |
+| SMS  | [Learn more about SMS](../../services/sms).  |
+| Application Token  | Authenticates your identity when using the emnify SDK and API. [Learn how to generate an application token](https://www.emnify.com/developer-blog/how-to-use-an-application-token-for-api-authentication).  |
+
+:::tip
+More terminology and definitions are available in the [Developer Glossary](glossary). 
+:::
+

--- a/docs/sdks/python/examples.md
+++ b/docs/sdks/python/examples.md
@@ -1,0 +1,362 @@
+---
+description: Code samples showing how to use the SDK
+---
+
+# Examples
+
+## Getting your first device online
+
+Follow the steps in the next code block comments to get your devices online.
+
+This example demonstrates complex operations across multiple SDK [Concepts](concepts), such as:
+
+- [Device policies](https://portal.emnify.com/device-policies) (configures which services are available and where)
+- SIM registration
+- Device creation
+- SIM assignment
+- Error handling
+- Device details retrieval
+- Device activation or deactivation
+
+:::tip
+You can [learn more about APN configuration via SMS](https://support.emnify.com/hc/en-us/articles/4401906757906-How-to-configure-the-APN-on-different-devices) on our Support page.
+:::
+
+```python title="mass_sim_activation.py"
+from emnify import EMnify
+from emnify import constants
+from emnify.errors import EMnifyBaseException
+
+# === Example: Getting your first device online ===
+
+# To operate the emnify SDK, you need to generate an application token.
+# Step-by-step guide: https://www.emnify.com/developer-blog/how-to-use-an-application-token-for-api-authentication
+token = input('token: ')
+# The client is authorized to perform operations by your name:
+emnify_client = EMnify(token)
+
+# Before getting your device online, you need a device and a SIM card.
+# This example assumes you have a batch of SIM cards for your devices.
+sim_batch_BIC2 = input('BIC2: ')
+
+# emnify allows you to control your coverage and services.
+# You can find those IDs on the Portal: https://portal.emnify.com/device-policies 
+service_profile_id = input('Service Profile ID: ')
+tariff_profile_id = input('Tariff Profile ID: ')
+# In order to create devices for SIMs afterwards we need service and coverage profiles.
+service_profile = emnify_client.devices.service_profile_model(id=int(service_profile_id))
+tariff_profile = emnify_client.devices.tariff_profile_model(id=int(tariff_profile_id))
+
+try:
+    # You need to add the SIM card batch to your account.
+    # This method also supports single sim registration via BIC1.
+    # (meaning you can use your free Evaluation SIM cards)
+    issued_sims = emnify_client.sim.register_sim(bic=sim_batch_BIC2)
+    # All of the added SIMs are now registered with "Issued" status.
+except EMnifyBaseException as e:
+    # If an error appears during SIM registration,
+    # use EMnifyBaseException for general exceptions 
+    # or inherited classes for specific ones.
+    raise AssertionError(f"error during sim batch BIC2 activation{e}")
+
+# We also need to define the device status to be applied during creation.
+device_status = emnify_client.devices.status_model(
+    **constants.DeviceStatuses.ENABLED_DICT.value
+)
+
+
+for sim in issued_sims:
+    # Only registering a SIM card won't provide connectivity.
+    # You also need to create a new device with the SIM assigned.
+
+    # For device creation, we need to specify the parameters of the device:
+    device_name = f"Device({sim.iccid})"
+    device_model = emnify_client.devices.device_create_model(
+        tariff_profile=tariff_profile,
+        status=device_status,
+        service_profile=service_profile,
+        sim=sim,
+        name=device_name
+    )
+
+    # See the API Reference to learn other device parameters:
+    # https://emnify.github.io/emnify-sdk-python/autoapi/index.html
+
+    # Here's how we create the device we want:
+    device_id = emnify_client.devices.create_device(device=device_model)
+
+    # After creation, we're able to retrieve full device information.
+    # You can store this information in your local inventory for future needs.
+    device = emnify_client.devices.retrieve_device(device_id=device_id)
+
+    # Connectivity is disabled by default (so you're not getting billed).
+    # The following command will enable connectivity for your device with a SIM card installed:
+    emnify_client.devices.change_status(enable=True, device=device)
+
+    # At this point, emnify can provide connectivity services.
+    # You can already send and receive SMS (if enabled in the assigned Service Profile).
+
+    # After the device is created and enabled, you need to configure it.
+
+    # Proper APN configuration of the device is required to access internet.
+    # The emnify APN is: em (two characters, no spaces)
+    # For example purposes, we'll send a special configuration SMS command:
+    ACTIVATION_CODE = 'AT+CGDCONT=1,"IP","em",,'
+    SENDER = "city_scooters_admin"
+
+    activation_sms = emnify_client.devices.sms_create_model(
+        payload=ACTIVATION_CODE,
+        source_adress=SENDER
+    )
+    # This configuration may vary by the device manufacturer.
+    # See our documentation to learn if this method suits your devices.
+
+    # Finally, send the configuration SMS to the device:
+    emnify_client.devices.send_sms(device=device, sms=activation_sms)
+
+    # Congratulations! Your device is online!
+    # Now, you can check your device's internet access.
+```
+
+## Device status management
+
+### Initialization of the SDK client
+
+```python title="device_lifecycle_management.py"
+from emnify import EMnify
+from emnify import constants as emnify_constants
+
+emnify = EMnify(app_token='your token')
+```
+
+### Create and activate a device
+
+- Device creation
+- SIM registration
+- SIMs listing
+- Device details retrieval
+- Device activation or deactivation
+
+```python title="device_lifecycle_management.py"
+#  === Example: Create and activate a device ===
+
+unassigned_sims = [i for i in emnify.sim.get_sim_list(without_device=True)]
+#  If there are no unassigned_sims, register a new one by batch code:
+if not unassigned_sims:
+    registered_sim = emnify.sim.register_sim(bic='sample_bic_code')  # Returns a list
+    sim = emnify.sim.retrieve_sim(registered_sim[0].id)
+else:
+    sim = unassigned_sims[0]  # Takes the first unassigned SIM
+
+# Defining new device parameters
+# All required models can be retrieved through the manager's properties
+service_profile = emnify.devices.service_profile_model(id=1)
+tariff_profile = emnify.devices.tariff_profile_model(id=1)
+device_status = emnify.devices.status_model(id=0)
+name = 'new_device'
+device_model = emnify.devices.device_create_model(
+    tariff_profile=tariff_profile,
+    status=device_status,
+    service_profile=service_profile,
+    sim=sim,
+    name=name
+)
+
+# After creation, the model SDK returns the id of the device:
+device_id = emnify.devices.create_device(device=device_model)
+# Then you can retrieve all of the device details:
+device = emnify.devices.retrieve_device(device_id=device_id)
+# Finally, activate the device:
+emnify.devices.change_status(device=device, enable=True)
+
+# Retrieving updated device details
+device = emnify.devices.retrieve_device(device_id=device_id)
+device_status = device.status.description  # Device status will be 'Enabled'
+sim_status = device.sim.status.description  # Device status will be 'Activated'
+```
+
+### Configure a device
+
+```python title="device_lifecycle_management.py"
+#  === Example: Configure a device ===
+
+# Retrieving device details
+device = emnify.devices.retrieve_device(device_id=device_id)
+
+tags = 'arduino, meter, temp'  # Sample tags
+name = 'new name'  # Sample name
+
+# Adjust the device configuration
+update_device_fields = emnify.devices.device_update_model(name='new name', tags='arduino')
+emnify.devices.update_device(device_id=device.id, device=update_device_fields)
+
+# Retrieving updated device details
+updated_device = emnify.devices.retrieve_device(device_id=device_id)
+device_tags = updated_device.tags  # Updated tag will be 'arduino'
+deivce_name = updated_device.name  # Updated name will be 'new name'
+```
+
+### Configure operator blocklist for device
+
+You may want to refrain from using a specific operator to avoid incurring costs with the device.
+
+This is possible by adding the operator to the blocklist of the device:
+
+```python title="device_lifecycle_management.py"
+#  === Example: Configure operator blocklist for device ===
+
+# Retrieve a list of all operators
+all_operators = [i for i in emnify.operator.get_operators()]
+
+# The following adds three operators to the blocklist:
+device_id = 0  # Your device id
+emnify.devices.add_device_blacklist_operator(operator_id=all_operators[0].id, device_id=device_id)
+emnify.devices.add_device_blacklist_operator(operator_id=all_operators[1].id, device_id=device_id)
+emnify.devices.add_device_blacklist_operator(operator_id=all_operators[2].id, device_id=device_id)
+
+# Gets all blocklist operators of the device by device_id:
+device_blacklist = emnify.devices.get_device_operator_blacklist(device_id=device_id)
+
+operator_id = 0
+for operator in device_blacklist:
+    print(operator.country)
+    print(operator.id)
+    print(operator.mnc)
+    operator_id = operator.id
+
+# Removes the last operator from the blocklist
+emnify.devices.delete_device_blacklist_operator(device_id=device_id, operator_id=operator_id)
+```
+
+### Disable device
+
+```python title="device_lifecycle_management.py"
+#  === Example: Disable device ===
+
+device_filter = emnify.devices.get_device_filter_model(status=emnify_constants.DeviceStatuses.ENABLED_ID.value)
+all_devices_with_sim = [
+    device for device in emnify.devices.get_devices_list(filter_model=device_filter) if device.sim
+]
+
+# Gets a list of all devices with SIM cards and the 'Enabled' status
+device = all_devices_with_sim[0]
+
+# Disables a device
+emnify.devices.change_status(disable=True, device=device.id)
+
+disabled_device = emnify.devices.retrieve_device(device_id=device.id)
+device_status = disabled_device.status.description  # Device status will be 'Disabled'
+sim_status = disabled_device.sim.status.description # SIM status will be 'Suspended'
+```
+
+### Delete device
+
+```python title="device_lifecycle_management.py"
+#  === Example: Delete device ===
+
+old_devices_list = [device for device in emnify.devices.get_devices_list()]
+
+# Gets a list of all devices
+device_to_delete = list(
+        filter(
+            lambda device: device.sim and device.status.id == emnify_constants.DeviceStatuses.ENABLED_ID,
+            old_devices_list
+        )
+)[0]
+
+# Pick a device to delete with an assigned SIM and the 'Enabled' status
+sim_id_of_deleted_device = device_to_delete.sim.id
+
+emnify.devices.delete_device(device_id=device_to_delete.id)
+
+# Deletes a device
+new_device_list = [device for device in emnify.devices.get_devices_list()]
+
+# Gets a new list of all devices
+assert len(old_devices_list) > len(new_device_list)
+# After deleting, the total device count will be lowered.
+
+sim = emnify.sim.retrieve_sim(sim_id=sim_id_of_deleted_device)
+sim_status = sim.status.description  # SIM status will be 'Suspended'
+```
+
+### Filtering and sorting
+
+```python title="filtering_and_sorting.py"
+# === Example: Using a Filtering for List calls  ===
+from emnify import EMnify
+from emnify import constants as emnify_constants
+
+emnify_client = EMnify(app_token='your_application_token')
+
+# Some methods that return multiple objects allow sorting and filtering.
+# This optimizes processing time because:
+# * Filtering enables you to immediately get the necessary objects with the necessary qualities.
+# * Sorting allows you to set the order objects are displayed.
+# Instead of sending several requests searching for the required object, you only need one.
+
+# This example finds all SIMs for a specific customer organization.
+# Specifying the necessary parameters as arguments initiates the model for filtering.
+sim_filter = emnify_client.sim.get_sim_filter_model(customer_org=1)
+
+# To retrieve the filtering model for filling, you need to get it as a property of a SIM card manager: get_sim_filter_model
+# For devices, it would be: get_device_filter_model
+
+# After initializing the model object, you must pass it as an argument to request a list of objects.
+sims = emnify_client.sim.get_sim_list(filter_model=sim_filter)
+# Now, the sims variable contains the objects for customer organization 1.
+
+# For a more detailed search, pass several parameters for filtering:
+sim_filter = emnify_client.sim.get_sim_filter_model(
+    customer_org=1,
+    status=emnify_constants.SimStatusesID.ACTIVATED_ID.value,
+    production_date='2019-01-25'
+)
+
+# The list SIM cards request also has a separate filter, passed as an argument.
+# The following example searches for SIMs without a device:
+sims_without_assigned_device = emnify_client.sim.get_sim_list(without_device=True)
+
+
+# === Example: Using sorting on list calls  ===
+
+# Like filtering, sorting reduces processing time by ordering objects in the server.
+# Sorting enables you to group objects by specifying a particular attribute.
+
+# The following example sorts all devices by the last updated date:
+sort_parameter = emnify_client.devices.get_device_sort_enum.LAST_UPDATED.value
+# Note that all sorting uses enums.
+
+# After choosing a filtering parameter, pass it as an argument to sort_enum:
+sorted_devices = emnify_client.devices.get_devices_list(
+    sort_enum=sort_parameter
+)
+
+# Now, you have a list of devices with the most recently updated at the top.
+for latest_device in sorted_devices:
+    ...
+```
+
+### Manage device connectivity
+
+[Connectivity troubleshooting](https://www.emnify.com/developer-blog/5-ways-to-detect-and-solve-connectivity-issues#network-events)
+
+```python title="device_lifecycle_management.py"
+#  === Manage device connectivity ===
+
+# There are many reasons why connection issues arise. For example:
+# * The device executes the wrong procedures due to a bad firmware update.
+# * The device executes network registration too frequently, so the network no longer allows it to register.
+# * You changed a policy for a blocked device.
+
+# To reset device connectivity, use the following methods:
+# * Resetting the device's data connectivity
+device_id = 0
+emnify.devices.reset_connectivity_data(device_id=device_id)
+# * Resetting the network connectivity
+emnify.devices.reset_connectivity_network(device_id=device_id)
+
+# For checking the connectivity, use the following method:
+connectivity = emnify.devices.get_device_connectivity_status(device_id=device_id)
+print(connectivity.status.description)  # Status will be either 'Attached,' 'Online,' 'Offline,' or 'Blocked.'
+```

--- a/docs/sdks/python/getting-started.md
+++ b/docs/sdks/python/getting-started.md
@@ -1,0 +1,64 @@
+---
+description: Step-by-step guide for installing and using the SDK
+---
+
+# Getting started with the emnify Python SDK
+
+## Installation
+
+### Requirements
+
+- Python ([version 3.6.0](https://www.python.org/downloads/release/python-360/) or higher)
+
+### From source code
+
+```bash
+git clone https://github.com/emnify/emnify-sdk-python.git
+cd emnify-sdk-python
+python setup.py install
+```
+
+### Using PyPI
+
+The emnify Python SDK is also available on [PyPI as `emnify-sdk`](https://pypi.org/project/emnify-sdk/):
+
+```bash
+pip install emnify-sdk
+```
+
+## Configuration
+
+### Create an application token
+
+To use the Python SDK, you need to create an application token. 
+You can do this via the [emnify Portal](https://portal.emnify.com/) or [emnify REST API](https://www.emnify.com/developer-blog/how-to-use-an-application-token-for-api-authentication).
+
+Once created, you'll apply it to initiate the SDK.
+
+### Using the SDK
+
+```python
+TOKEN = '<PASTE YOUR APPLICATION TOKEN HERE>'
+
+# Import the package
+from emnify import EMnify
+
+# Initiate the SDK instance using your application token
+emnify = EMnify(TOKEN)
+
+# Execute a command against the desired API
+devices = emnify.devices.get_devices_list()
+
+# Show all the devices
+print([device for device in devices])
+```
+
+## Explore more 
+
+Now that you have the SDK configured, it's time to learn what you can do with it.
+
+If you're new to IoT connectivity and emnify, start by learning the [common terminology and concepts](concepts). 
+
+Once you're comfortable with these [concepts](concepts), you can explore some use cases that show what the SDK is capable of based on a few [Examples](examples). 
+
+Also, see the [*emnify System Documentation*](https://cdn.emnify.net/api/doc/index.html) and our [OpenAPI Specification](https://cdn.emnify.net/api/doc/swagger.html).

--- a/docs/sdks/python/help.md
+++ b/docs/sdks/python/help.md
@@ -1,0 +1,8 @@
+---
+description: Get support and give us feedback
+---
+
+# Help and contributing
+
+- If you need help using our services, please [file a support ticket](https://support.emnify.com/hc/en-us/requests/new).
+- If you've found a bug in the library or would like to add new features, go ahead and [open issues or pull requests to our Github repository](https://github.com/EMnify/emnify-sdk-python).

--- a/docs/services/events/event-types.md
+++ b/docs/services/events/event-types.md
@@ -198,7 +198,7 @@ SIM is patched from **Issued** to **Factory Test** status (for SIM testing).
 
 ### SIM registration
 
-SIM or SIM batch is registered to an organization via a [Batch Identification Code (BIC)](https://www.emnify.com/developers/documentation#_glossary). 
+SIM or SIM batch is registered to an organization via a [Batch Identification Code (BIC)](../../glossary#bic---batch-identification-code). 
 
 :::note
 This event doesn't trigger when the emnify team assigns SIMs to an organization. 

--- a/sidebars.js
+++ b/sidebars.js
@@ -90,6 +90,43 @@ const sidebars = {
         'services/no-code-workflow-automation',
         'services/sim-life-cycle-management',
         'services/endpoint-management-and-group-policies',
+      ]
+    },
+    {
+      type: 'category',
+      label: 'Software Development Kits',
+      link: { 
+        type: 'generated-index', 
+        title: 'emnify SDKs',
+        description: 'The emnify software development kits (SDKs) allow developers to manage their IoT devices using an intuitive set of APIs, including SIM state management and device connectivity operations.',
+        slug: '/sdks'
+      },
+      items: [
+        {
+          type: 'category',
+          label: 'Python',
+          link: { 
+            type: 'generated-index', 
+            title: 'emnify Python SDK',
+            description: 'The alpha release of the new emnify Python software development kit (SDK) for SIM state management and device connectivity operations.',
+            slug: '/sdks/python'
+          },
+          items: [
+            {
+              type: 'doc',
+              label: 'Getting started',
+              id: 'sdks/python/getting-started'
+            },
+            'sdks/python/concepts',
+            'sdks/python/examples',
+            'sdks/python/help',
+            {
+              type: 'link',
+              label: 'API Reference',
+              href: 'https://emnify.github.io/emnify-sdk-python/autoapi/index.html'
+            }
+          ],
+        },
       ],
     },
     'rest-api',


### PR DESCRIPTION
Now that we know where our SDK content lives, let's add it to our migration 🐍 

💹 What's in this PR:
- Content from the current Python SDK (aka all of the [`rst` files in this directory](https://github.com/EMnify/emnify-sdk-python/tree/main/docs/sphinx))
⚠️ _**Minimal language clean up done. Another ticket is open for verifying and updating the content.**_ 
- `generated-index` files for the SDK category and Python sub-category
- External link in the sidebar to the auto-generated API reference docs (we will migrate in a later ticket)

Internal ticket 🎟️  [SDOCS-72](https://emnify.atlassian.net/browse/SDOCS-72)



[SDOCS-72]: https://emnify.atlassian.net/browse/SDOCS-72?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ