### PR TITLE
Override default Infima variables to reflect new emnify branding

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,5 +1,6 @@
 // @ts-check
-const lightCodeTheme = require("prism-react-renderer/themes/github");
+const lightCodeTheme = require("prism-react-renderer/themes/vsLight");
+const darkCodeTheme = require("prism-react-renderer/themes/oceanicNext");
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
@@ -53,7 +54,6 @@ const config = {
         },
       },
       footer: {
-        style: "dark",
         links: [
           {
             title: "Resources",

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,6 +1,6 @@
 // @ts-check
 const lightCodeTheme = require("prism-react-renderer/themes/vsLight");
-const darkCodeTheme = require("prism-react-renderer/themes/oceanicNext");
+const darkCodeTheme = require("prism-react-renderer/themes/dracula");
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -17,6 +17,7 @@
   --ifm-footer-background-color: #F2F2F2;
   --ifm-footer-link-color: #000035;
   /* Sidebar */
+  --ifm-menu-color: #404067;
   --ifm-menu-color-background-active: #010D410F;
   --ifm-menu-color-background-hover: #010D410F;
   /* Breadcrumb */

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1,5 +1,5 @@
 :root {
-    /* Text and content */
+  /* Text and content */
   --ifm-font-family-base: 'Avenir LT Pro', Helvetica, Arial, sans-serif;
   --ifm-color-content: #000035; 
   --ifm-color-content-secondary: #404067;
@@ -35,6 +35,22 @@
 
 .theme-doc-markdown a:hover, .theme-edit-this-page:hover {
   color: #404067;
+}
+
+.theme-doc-markdown table a {
+  text-decoration: none;
+}
+
+.theme-doc-markdown table a:hover {
+  text-decoration: underline;
+}
+
+.theme-doc-markdown .hash-link {
+  text-decoration: none;
+}
+
+.theme-doc-markdown .hash-link:hover {
+  text-decoration: underline;
 }
 
 /* Caution adminition */

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1,18 +1,63 @@
-/**
- * Any CSS included here will be global. The classic template
- * bundles Infima by default. Infima is a CSS framework designed to
- * work well for content-centric websites.
- */
-
-/* You can override the default Infima variables here. */
 :root {
-  --ifm-color-primary: #0065b3;
-  --ifm-color-primary-dark: #29784c;
-  --ifm-color-primary-darker: #277148;
-  --ifm-color-primary-darkest: #205d3b;
+  --ifm-font-family-base: 'Avenir LT Pro', Helvetica, Arial, sans-serif;
+  --ifm-color-content: #000035;
+  --ifm-color-primary: #000035;
+  --ifm-footer-background-color: #F2F2F2;
+  --ifm-footer-link-color: #000035;
+  --ifm-menu-color-background-active: #010D410F;
+  --ifm-color-primary-dark: #000035;
+  --ifm-color-primary-darker: #000035;
+  --ifm-color-primary-darkest: #000035;
   --ifm-color-primary-light: #33925d;
   --ifm-color-primary-lighter: #359962;
   --ifm-color-primary-lightest: #3cad6e;
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
+}
+
+/* For readability concerns, you should choose a lighter palette in dark mode. */
+[data-theme='dark'] {
+  --ifm-color-content: #F5F5F5;
+  --ifm-footer-background-color: #404067;
+  --ifm-footer-link-color: #F5F5F5;
+  --ifm-color-primary: #F5F5F5;
+  --ifm-color-primary-dark: #F5F5F5;
+  --ifm-color-primary-darker: #F5F5F5;
+  --ifm-color-primary-darkest: #F5F5F5;
+  --ifm-color-primary-light: #29d5b0;
+  --ifm-color-primary-lighter: #32d8b4;
+  --ifm-color-primary-lightest: #4fddbf;
+  --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
+}
+
+html[data-theme='dark'] {
+  --ifm-background-color: #000035;
+  --ifm-background-surface-color: #000035;
+}
+
+article {
+  max-width: 700px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+@media screen and (max-width: 996px) {
+  :root {
+    --ifm-font-size-base: 18px;
+  }
+  article header h1 {
+    font-size: 1.5rem !important;
+  }
+  .hero .hero__title {
+    font-size: 2.5rem;
+  }
+}
+
+@media screen and (min-width: 997px) {
+  :root {
+    --ifm-font-size-base: 17px;
+  }
+  article header h1 {
+    font-size: 2rem !important;
+  }
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1,63 +1,24 @@
 :root {
   --ifm-font-family-base: 'Avenir LT Pro', Helvetica, Arial, sans-serif;
-  --ifm-color-content: #000035;
+  --ifm-color-content: #000035; 
+  --ifm-color-content-secondary: #404067;
   --ifm-color-primary: #000035;
   --ifm-footer-background-color: #F2F2F2;
   --ifm-footer-link-color: #000035;
   --ifm-menu-color-background-active: #010D410F;
-  --ifm-color-primary-dark: #000035;
-  --ifm-color-primary-darker: #000035;
+  --ifm-color-primary-dark: #80809A; 
+  --ifm-color-primary-darker: #404067;
   --ifm-color-primary-darkest: #000035;
-  --ifm-color-primary-light: #33925d;
-  --ifm-color-primary-lighter: #359962;
-  --ifm-color-primary-lightest: #3cad6e;
+  --ifm-color-primary-light: #60E524;
+  --ifm-color-primary-lighter: #4EE794;
+  --ifm-color-primary-lightest: #DFF6D5;
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
+  --ifm-color-emphasis: #404067;
+  --ifm-link-hover-color: #404067;
+  --ifm-menu-color-background-hover: #010D410F;
 }
 
-/* For readability concerns, you should choose a lighter palette in dark mode. */
-[data-theme='dark'] {
-  --ifm-color-content: #F5F5F5;
-  --ifm-footer-background-color: #404067;
-  --ifm-footer-link-color: #F5F5F5;
-  --ifm-color-primary: #F5F5F5;
-  --ifm-color-primary-dark: #F5F5F5;
-  --ifm-color-primary-darker: #F5F5F5;
-  --ifm-color-primary-darkest: #F5F5F5;
-  --ifm-color-primary-light: #29d5b0;
-  --ifm-color-primary-lighter: #32d8b4;
-  --ifm-color-primary-lightest: #4fddbf;
-  --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
-}
-
-html[data-theme='dark'] {
-  --ifm-background-color: #000035;
-  --ifm-background-surface-color: #000035;
-}
-
-article {
-  max-width: 700px;
-  margin-left: auto;
-  margin-right: auto;
-}
-
-@media screen and (max-width: 996px) {
-  :root {
-    --ifm-font-size-base: 18px;
-  }
-  article header h1 {
-    font-size: 1.5rem !important;
-  }
-  .hero .hero__title {
-    font-size: 2.5rem;
-  }
-}
-
-@media screen and (min-width: 997px) {
-  :root {
-    --ifm-font-size-base: 17px;
-  }
-  article header h1 {
-    font-size: 2rem !important;
-  }
+.theme-doc-markdown a, .theme-edit-this-page {
+  --ifm-link-decoration: underline;
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1,24 +1,112 @@
 :root {
+    /* Text and content */
   --ifm-font-family-base: 'Avenir LT Pro', Helvetica, Arial, sans-serif;
   --ifm-color-content: #000035; 
   --ifm-color-content-secondary: #404067;
   --ifm-color-primary: #000035;
-  --ifm-footer-background-color: #F2F2F2;
-  --ifm-footer-link-color: #000035;
-  --ifm-menu-color-background-active: #010D410F;
   --ifm-color-primary-dark: #80809A; 
   --ifm-color-primary-darker: #404067;
   --ifm-color-primary-darkest: #000035;
   --ifm-color-primary-light: #60E524;
   --ifm-color-primary-lighter: #4EE794;
   --ifm-color-primary-lightest: #DFF6D5;
-  --ifm-code-font-size: 95%;
-  --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
   --ifm-color-emphasis: #404067;
+  /* Links */
   --ifm-link-hover-color: #404067;
+  /* Footer */
+  --ifm-footer-background-color: #F2F2F2;
+  --ifm-footer-link-color: #000035;
+  /* Sidebar */
+  --ifm-menu-color-background-active: #010D410F;
   --ifm-menu-color-background-hover: #010D410F;
+  /* Breadcrumb */
+  --ifm-breadcrumb-item-background-active: #010D410F;
+  /* Buttons */
+  --ifm-button-background-color: #000035;
+  /* Code blocks */
+  --ifm-code-font-size: 95%;
 }
 
+/* Links within documentation content */
 .theme-doc-markdown a, .theme-edit-this-page {
   --ifm-link-decoration: underline;
+}
+
+.theme-doc-markdown a:hover, .theme-edit-this-page:hover {
+  color: #404067;
+}
+
+/* Caution adminition */
+.theme-admonition-caution {
+  background-color: #F2740014;
+  border-color: #F27400;
+  color: #263238;
+}
+
+.theme-admonition-caution a {
+  text-decoration-color: #F27400;
+}
+
+.theme-admonition-caution svg path {
+  fill: #F27400;
+}
+
+/* Tip adminition */
+.theme-admonition-tip {
+  background-color: #3D9A3214;
+  border-color: #009E19;
+  color: #263238;
+}
+
+.theme-admonition-tip a {
+  text-decoration-color: #009E19;
+}
+
+.theme-admonition-tip svg path {
+  fill: #009E19;
+}
+
+/* Danger adminition */
+.theme-admonition-danger {
+  background-color: #DA353514;
+  border-color: #DA3535;
+  color: #263238;
+}
+
+.theme-admonition-danger a {
+  text-decoration-color: #DA3535;
+}
+
+.theme-admonition-danger svg path {
+  fill: #DA3535;
+}
+
+/* Info adminition */
+.theme-admonition-info {
+  background-color: #EDF3F8;
+  border-color: #659BDF;
+  color: #263238;
+}
+
+.theme-admonition-info a {
+  text-decoration-color: #659BDF;
+}
+
+.theme-admonition-info svg path {
+  fill: #659BDF;
+}
+
+/* Note adminition */
+.theme-admonition-note {
+  background-color: #F5F5F5;
+  border-color: #E4E4E4;
+  color: #263238;
+}
+
+.theme-admonition-note a {
+  text-decoration-color: #E4E4E4;
+}
+
+.theme-admonition-note svg path {
+  fill: #263238;
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1,3 +1,4 @@
+/* Overrides the default Infima (https://infima.dev/) variables */
 :root {
   /* Text and content */
   --ifm-font-family-base: 'Avenir LT Pro', Helvetica, Arial, sans-serif;


### PR DESCRIPTION
Basic design to enable our new documentation platform to match the Portal and the new branding guidelines. It's not the most beautiful CSS ever, but we can iterate as the Portal design evolves 😅 

🖌️ **What changed in this PR:**
- Overrode the default Infima variables to reflect new branding and Portal design
  - Font family
  - Colors (see below)
  - Link style   
- Changed the `lightCodeTheme` to a more accessible color scheme
- Removed boilerplate comments in `custom.css` 

🙅🏼 **Not included:**
- Dark mode (removed in #20)
- Any of the generated carets (in sidebar and breadcrumbs, examples below)

<details>
<summary>Caret .menu__caret</summary>
<img width="423" alt="Screenshot 2023-01-04 at 11 06 37" src="https://user-images.githubusercontent.com/26869552/210540556-64318631-066e-4ff0-8295-d48c0c86e6d9.png">
</details>

<details>
<summary>Caret .breadcrumbs__item:not(:last-child)::after</summary>
<img width="481" alt="Screenshot 2023-01-04 at 11 06 21" src="https://user-images.githubusercontent.com/26869552/210540799-6edeca21-c659-46c1-95fc-5fa780618e43.png">
</details>

[Internal Figma file](https://www.figma.com/file/9RHWIr1lG3UpvYZHCF4CfZ/Concepts%2FIdeas?node-id=1481%3A208908&t=hqIxGqmef0Jn7qpN-0) 🎨 
Internal ticket 🎟️ [SDOCS-129](https://emnify.atlassian.net/browse/SDOCS-129)

### Screenshots

✨ **Main documentation content**
<img width="1507" alt="Screenshot 2023-01-04 at 11 00 55" src="https://user-images.githubusercontent.com/26869552/210536295-d6c85a97-7661-4b77-9930-5e960e1e0f82.png">
<details>
<summary>Currently on main</summary>
<img width="1511" alt="Screenshot 2023-01-04 at 11 12 44" src="https://user-images.githubusercontent.com/26869552/210541033-135c7457-e1f7-4504-877f-e20bea0f1c0b.png">
</details>

✨ **Code blocks with vsLight theme**
<img width="916" alt="Screenshot 2023-01-04 at 11 20 43" src="https://user-images.githubusercontent.com/26869552/210541217-c3301a3b-5077-4310-b468-311232ec02bd.png">
<details>
<summary>Currently on main</summary>
<img width="706" alt="Screenshot 2023-01-04 at 12 02 02" src="https://user-images.githubusercontent.com/26869552/210541405-a01da9cd-fc18-4597-ab5d-c3b2d08fcd30.png">
</details>

✨ **Tip and caution admonitions**
<img width="914" alt="Screenshot 2023-01-04 at 11 01 22" src="https://user-images.githubusercontent.com/26869552/210541556-5d3280b6-65d5-4f8c-bd5f-da71c916106c.png">
<details>
<summary>Currently on main</summary>
<img width="908" alt="Screenshot 2023-01-04 at 11 13 14" src="https://user-images.githubusercontent.com/26869552/210541667-b1501b5e-d27b-4b1d-8581-a7232f8c0807.png">
</details>

✨  **Danger admonition**
<img width="849" alt="Screenshot 2023-01-04 at 11 02 00" src="https://user-images.githubusercontent.com/26869552/210541722-de8c4683-401b-4b17-b407-81e389476f28.png">
<details>
<summary>Currently on main</summary>
<img width="921" alt="Screenshot 2023-01-04 at 11 13 02" src="https://user-images.githubusercontent.com/26869552/210541781-048c386a-022e-48c8-8f89-304b22c6fd33.png">
</details>

✨  **Note and info admonition**
<img width="835" alt="Screenshot 2023-01-04 at 11 02 24" src="https://user-images.githubusercontent.com/26869552/210541867-824b4ad3-f25d-4511-9e1b-d993d84ebe9d.png">
<details>
<summary>Currently on main</summary>
<img width="913" alt="Screenshot 2023-01-04 at 11 13 40" src="https://user-images.githubusercontent.com/26869552/210541964-263c35db-3fef-4c50-861d-62801b0edb6e.png">
</details>

> ℹ️  _Note about the note admonition_: It doesn't follow the same design pattern as the others where the svg fill matches the border color because it was too light. Decided to opt for making it the same color as the text instead. Included a screenshot below for reference.

<details>
<summary>Note admonition following the consistent design pattern</summary>
<img width="641" alt="Screenshot 2023-01-03 at 21 52 42" src="https://user-images.githubusercontent.com/26869552/210542672-ce59c998-9628-461e-98e1-d0cb763ce30a.png">
</details>

[SDOCS-129]: https://emnify.atlassian.net/browse/SDOCS-129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ