### PR TITLE
SEO: Add global metadata, fix page metadata

### DIFF
--- a/docs/services/data-streamer/getting-started.md
+++ b/docs/services/data-streamer/getting-started.md
@@ -1,5 +1,4 @@
 ---
-title: Getting started
 description: Benefits of the Data Streamer and how you can get started
 ---
 

--- a/docs/services/events/getting-started.md
+++ b/docs/services/events/getting-started.md
@@ -1,5 +1,4 @@
 ---
-title: Getting started
 description: Learn the basics and structure of emnify events
 ---
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -43,6 +43,31 @@ const config = {
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
+      metadata: [
+        {
+          name: 'description', 
+          content: 'Check our documentation for emnify API and Services including Data Streamer, Cloud Connect, Security, SIM management.'
+        },
+        {
+          property: 'og:title',
+          content: 'Documentation for Developers | emnify'
+        },
+        {
+          property: 'og:description',
+          content: 'Check our documentation for emnify API and Services including Data Streamer, Cloud Connect, Security, SIM management.'
+        },
+        {
+          name: 'twitter:title',
+          content: 'Documentation for Developers | emnify'
+        },
+        {
+          name: 'twitter:description',
+          content: 'Check our documentation for emnify API and Services including Data Streamer, Cloud Connect, Security, SIM management.'
+        },
+        {
+
+        }
+      ],
       colorMode: {
         disableSwitch: true
       },

--- a/sidebars.js
+++ b/sidebars.js
@@ -58,7 +58,11 @@ const sidebars = {
             slug: 'services/data-streamer'
           },
       items: [
-        'services/data-streamer/getting-started',
+        {
+          type: 'doc',
+          label: 'Getting started',
+          id: 'services/data-streamer/getting-started'
+        },
         'services/data-streamer/connection-types',
         'services/data-streamer/stream-types',
         'services/data-streamer/managing-data-streams',
@@ -75,7 +79,11 @@ const sidebars = {
             slug: 'services/events'
           },
           items: [
-            'services/events/getting-started',
+            {
+              type: 'doc',
+              label: 'Getting started',
+              id: 'services/events/getting-started'
+            },
             'services/events/event-types',
             'services/events/mno-events',
             'services/events/usage'


### PR DESCRIPTION
Quickly went through the [Docusaurus SEO guide](https://docusaurus.io/docs/next/seo) to make sure we weren't missing any essentials and made some fixes ✨ 

1️⃣  **Global metadata**
Added tags based on what's already in the [current developer documentation](https://www.emnify.com/developers/documentation). We may want to follow up and check these with Joao. 
<img width="545" alt="Screenshot 2023-01-04 at 20 01 40" src="https://user-images.githubusercontent.com/26869552/210631624-cb863b92-8714-4897-a418-005162554503.png">

2️⃣ **Use sidebar labels instead of altering page metadata**
In a previous PR, we opted for using the `title` field in frontmatter if we wanted to change the page title that appears on the sidebar. However, this apparently alters the title used in the `<head>` of the page. 

Because we're usually altering the sidebar to be shorter, opting for a `label` field in the `sidebar.js` is a better solution. By default, the site will pull the page's `<h1>` as the title, so we may want to consider going through these later. 

<img width="1512" alt="Screenshot 2023-01-04 at 19 56 40" src="https://user-images.githubusercontent.com/26869552/210632172-64a0989a-aa72-4f3d-81b4-a66d7b5f3fc4.png">

I've also updated this in #15 and #12 to reflect these findings 👀 

Internal ticket 🎟️  [SDOCS-145](https://emnify.atlassian.net/browse/SDOCS-145)

[SDOCS-145]: https://emnify.atlassian.net/browse/SDOCS-145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ