### PR TITLE
Specify emnify Documentation Maintainers team as CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+@emnify/documentation-maintainers


### PR DESCRIPTION
First step: 🔀 Merge this 
Second step: 🔏 Add protections to our `main` branch 

Specifies the [@emnify/documentation-maintainers](https://github.com/orgs/EMnify/teams/documentation-maintainers) as CODEOWNERS.