### PR TITLE
Apply temporary distinguished style for details elements

### DIFF
--- a/docs/services/data-streamer/stream-types.md
+++ b/docs/services/data-streamer/stream-types.md
@@ -55,7 +55,7 @@ Usage records for data are created:
 - Every 45 seconds for open PDP contexts (when at least 100 KB of data is consumed)
 - After the PDP context is closed
 
-<details>
+<details className="custom-details-example-json-response">
   <summary>Example JSON response</summary>
 
 ```json
@@ -140,7 +140,7 @@ Usage records for SMS are created when an SMS is successfully delivered either:
 - From the device (`"rx": 1`)
 - Towards the device (`"tx": 1`)
 
-<details>
+<details className="custom-details-example-json-response">
   <summary>Example JSON response</summary>
 
 ```json

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,6 +1,5 @@
 // @ts-check
 const lightCodeTheme = require("prism-react-renderer/themes/vsLight");
-const darkCodeTheme = require("prism-react-renderer/themes/dracula");
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -131,8 +131,9 @@
 
 /* Details and summary elements */
 .custom-details-example-json-response {
-  background-color: #0000350F !important;
+  background-color: #0000350F;
   border-color: #000035 !important;
+  color: #000035;
 }
 
 .custom-details-example-json-response summary::before {
@@ -140,5 +141,5 @@
 }
 
 .custom-details-example-json-response .collapsibleContent_node_modules-\@docusaurus-theme-common-lib-components-Details-styles-module {
-  border-top: 1px solid #000035 !important;
+  border-top: 1px solid #000035;
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -128,3 +128,17 @@
 .theme-admonition-note svg path {
   fill: #263238;
 }
+
+/* Details and summary elements */
+.custom-details-example-json-response {
+  background-color: #0000350F !important;
+  border-color: #000035 !important;
+}
+
+.custom-details-example-json-response summary::before {
+  border-color: transparent transparent transparent #000035 !important;
+}
+
+.custom-details-example-json-response .collapsibleContent_node_modules-\@docusaurus-theme-common-lib-components-Details-styles-module {
+  border-top: 1px solid #000035 !important;
+}


### PR DESCRIPTION
Previously, the `<details>` and `<summary>` elements inherited the styles from the info adminition, but given that sometimes these elements are stacked, it makes sense to distinguish these elements in the UI. 

This is a first iteration (specifically for the example JSON responses) until we can further coordinate with the design team and figure out a more effective way to apply universal styles to these details 🎨 

✨ What's in this PR:
- Implement custom class for details element that contain JSON example responses
- Remove unnecessary dark mode code theme variable

Unfortunately some of the CSS properties need the `!important` rule to override the default design 🥲 

<img width="557" alt="Screenshot 2023-01-08 at 15 43 42" src="https://user-images.githubusercontent.com/26869552/211218182-4934bef1-77bf-41f1-924e-d51b2acec041.png">

<details>
<summary>Before:</summary>
<img width="634" alt="Screenshot 2023-01-08 at 15 33 38" src="https://user-images.githubusercontent.com/26869552/211218121-9563b682-d4de-4af3-b569-082aa04cb8cd.png">
</details>

Internal ticket 🎟️  [SDOCS-147](https://emnify.atlassian.net/browse/SDOCS-147)

[SDOCS-147]: https://emnify.atlassian.net/browse/SDOCS-147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ