### PR TITLE
Update content and design of 404 page

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -30,11 +30,11 @@
 }
 
 /* Links within documentation content */
-.theme-doc-markdown a, .theme-edit-this-page {
+.theme-doc-markdown a, .theme-edit-this-page, .page-not-found-content a {
   --ifm-link-decoration: underline;
 }
 
-.theme-doc-markdown a:hover, .theme-edit-this-page:hover {
+.theme-doc-markdown a:hover, .theme-edit-this-page:hover, .page-not-found-content a:hover {
   color: #404067;
 }
 
@@ -142,4 +142,22 @@
 
 .custom-details-example-json-response .collapsibleContent_node_modules-\@docusaurus-theme-common-lib-components-Details-styles-module {
   border-top: 1px solid #000035;
+}
+
+/* 404 page button */
+.page-not-found-content .homepage-button {
+  background: #FFFFFF;
+  border: 1px solid #E0E0E0;
+  color: #263238;
+  font-family: 'Avenir LT Pro', Helvetica, Arial, sans-serif;
+  font-size: 14px;
+  font-weight: 750;
+  text-decoration: none;
+  text-transform: uppercase;
+  padding: 10px 20px;
+}
+
+.page-not-found-content .homepage-button:hover {
+  border: 1px solid #263238;
+  color: #263238;
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -30,11 +30,11 @@
 }
 
 /* Links within documentation content */
-.theme-doc-markdown a, .theme-edit-this-page, .page-not-found-content a {
+.theme-doc-markdown a, .theme-edit-this-page {
   --ifm-link-decoration: underline;
 }
 
-.theme-doc-markdown a:hover, .theme-edit-this-page:hover, .page-not-found-content a:hover {
+.theme-doc-markdown a:hover, .theme-edit-this-page:hover {
   color: #404067;
 }
 
@@ -142,22 +142,4 @@
 
 .custom-details-example-json-response .collapsibleContent_node_modules-\@docusaurus-theme-common-lib-components-Details-styles-module {
   border-top: 1px solid #000035;
-}
-
-/* 404 page button */
-.page-not-found-content .homepage-button {
-  background: #FFFFFF;
-  border: 1px solid #E0E0E0;
-  color: #263238;
-  font-family: 'Avenir LT Pro', Helvetica, Arial, sans-serif;
-  font-size: 14px;
-  font-weight: 750;
-  text-decoration: none;
-  text-transform: uppercase;
-  padding: 10px 20px;
-}
-
-.page-not-found-content .homepage-button:hover {
-  border: 1px solid #263238;
-  color: #263238;
 }

--- a/src/theme/NotFound.js
+++ b/src/theme/NotFound.js
@@ -3,6 +3,7 @@ import Translate, {translate} from '@docusaurus/Translate';
 import {PageMetadata} from '@docusaurus/theme-common';
 import Layout from '@theme/Layout';
 import Link from '@docusaurus/Link';
+import styles from './NotFound.module.css';
 
 export default function NotFound() {
   return (
@@ -35,9 +36,9 @@ export default function NotFound() {
               <p
                 id="theme.NotFound.p2"
                 description="The 2nd paragraph of the 404 page">
-                Please <a href="https://github.com/EMnify/product-docs/issues/new" target="_blank" rel="noopener noreferrer">open an issue on GitHub</a> or <a href="mailto:docs@emnify.com">contact our documentation team</a> if you're struggling to find what you need.
+                Please <a className={styles.pageLink} href="https://github.com/emnify/product-docs/issues/new" target="_blank" rel="noopener noreferrer">open an issue on GitHub</a> or <a className={styles.pageLink} href="mailto:docs@emnify.com">contact our documentation team</a> if you're struggling to find what you need.
               </p>
-              <Link to="/product-docs" className="homepage-button">Go to homepage</Link>
+              <Link to="/product-docs" className={styles.homepageButton}>Go to homepage</Link>
             </div>
           </div>
         </main>

--- a/src/theme/NotFound.js
+++ b/src/theme/NotFound.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import Translate, {translate} from '@docusaurus/Translate';
+import {PageMetadata} from '@docusaurus/theme-common';
+import Layout from '@theme/Layout';
+import Link from '@docusaurus/Link';
+
+export default function NotFound() {
+  return (
+    <>
+      <PageMetadata
+        title={translate({
+          id: 'theme.NotFound.title',
+          message: 'Page not found',
+        })}
+      />
+      <Layout>
+        <main className="container margin-vert--xl">
+          <div className="row">
+            <div className="col col--6 col--offset-3 page-not-found-content">
+              <h1 className="hero__title">
+                <Translate
+                  id="theme.NotFound.title"
+                  description="The title of the 404 page">
+                  Page not found
+                </Translate>
+              </h1>
+              <p>
+                <Translate
+                  id="theme.NotFound.p1"
+                  description="The first paragraph of the 404 page">
+                  We could not find what you were looking for. 
+                  The link to this page may be incorrect or out of date. 
+                </Translate>
+              </p>
+              <p
+                id="theme.NotFound.p2"
+                description="The 2nd paragraph of the 404 page">
+                Please <a href="https://github.com/EMnify/product-docs/issues/new" target="_blank" rel="noopener noreferrer">open an issue on GitHub</a> or <a href="mailto:docs@emnify.com">contact our documentation team</a> if you're struggling to find what you need.
+              </p>
+              <Link to="/product-docs" className="homepage-button">Go to homepage</Link>
+            </div>
+          </div>
+        </main>
+      </Layout>
+    </>
+  );
+}

--- a/src/theme/NotFound.module.css
+++ b/src/theme/NotFound.module.css
@@ -1,0 +1,27 @@
+/* Links within main page content */
+.pageLink {
+    --ifm-link-decoration: underline;
+  }
+  
+  .pageLink:hover {
+    color: #404067;
+  }
+
+/* Go to homepage button */
+.homepageButton {
+    background: #FFFFFF;
+    border: 1px solid #E0E0E0;
+    color: #263238;
+    font-family: 'Avenir LT Pro', Helvetica, Arial, sans-serif;
+    font-size: 14px;
+    font-weight: 750;
+    text-decoration: none;
+    text-transform: uppercase;
+    padding: 10px 20px;
+  }
+  
+.homepageButton:hover {
+    border: 1px solid #263238;
+    color: #263238;
+    text-decoration: none;
+  }


### PR DESCRIPTION
[Swizzled](https://docusaurus.io/docs/swizzling) the `NotFound` page from Docusaurus so that we could add custom UI elements and text. 

What's included 🔍 
- Newly added (and now customizable) `NotFound.js` page 
- An associated CSS module stylesheet (`NotFound.module.css`)
- Updated main content to encourage people to open an issue or email us if they have issues
- Updated text formatting and design elements to match our other pages
- "Back to homepage" button 

Visual preview ✨ 
<img width="1178" alt="Screenshot 2023-01-09 at 09 59 30" src="https://user-images.githubusercontent.com/26869552/211355126-c24351e0-7a38-4f1e-8879-32e13d3b750a.png">

<details>
<summary>Current page:</summary>
<img width="1175" alt="Screenshot 2023-01-09 at 10 00 59" src="https://user-images.githubusercontent.com/26869552/211355225-89fdcb5b-79ab-4918-8805-e54fd399f674.png">
</details>

🎨  [Figma file referenced ](https://www.figma.com/file/9RHWIr1lG3UpvYZHCF4CfZ/Concepts%2FIdeas?node-id=1481%3A208908&t=JOqVsbxaXAFIsuof-0)
🎟️ Internal ticket [SDOCS-66](https://emnify.atlassian.net/browse/SDOCS-66)

[SDOCS-66]: https://emnify.atlassian.net/browse/SDOCS-66?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ