### PR TITLE
Add important property to collapsible content top border override

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -141,5 +141,5 @@
 }
 
 .custom-details-example-json-response .collapsibleContent_node_modules-\@docusaurus-theme-common-lib-components-Details-styles-module {
-  border-top: 1px solid #000035;
+  border-top: 1px solid #000035 !important;
 }


### PR DESCRIPTION
This PR is an initial hail mary (🏈 ) as I'm having difficulty reproducing the bug locally. If we deploy this and it doesn't fix the issue, then I'll convert the `details` elements into proper MDX components (something we should probably do eventually anyway).

<details>
<summary>Expected look ✨</summary>
<img width="693" alt="Screenshot 2023-01-10 at 11 24 47" src="https://user-images.githubusercontent.com/26869552/211641293-497472b1-1b66-43a0-9c17-6f09711adfbe.png">
</details>

<details>
<summary>Currently deployed 🪲 </summary>
<img width="686" alt="Screenshot 2023-01-10 at 11 24 30" src="https://user-images.githubusercontent.com/26869552/211641424-4ff6693d-9bbc-4ffe-84d2-997d6dada883.png">
</details>

Internal ticket 🎫 [SDOCS-155](https://emnify.atlassian.net/browse/SDOCS-155)

[SDOCS-155]: https://emnify.atlassian.net/browse/SDOCS-155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ