### PR TITLE
Temporary fix for collapsible content top border override (round two)

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -140,6 +140,6 @@
   border-color: transparent transparent transparent #000035 !important;
 }
 
-.custom-details-example-json-response .collapsibleContent_node_modules-\@docusaurus-theme-common-lib-components-Details-styles-module {
+.custom-details-example-json-response .collapsibleContent_i85q {
   border-top: 1px solid #000035 !important;
 }


### PR DESCRIPTION
Second try (after #35) to find a temp fix for [SDOCS-155](https://emnify.atlassian.net/browse/SDOCS-155) without having to build a custom MDX component 🥴 

⚠️ **_Running this fix locally won't show a difference_** ⚠️ 
However, I'm convinced it may work once deployed because it's directly targeting that class name.
<img width="1401" alt="Screenshot 2023-01-11 at 22 27 01" src="https://user-images.githubusercontent.com/26869552/211976585-a36de088-8ecb-4a87-9503-51ddf0328b1f.png">

Worst case, it doesn't work and we're in the same position 🤷🏼‍♀️ 

[SDOCS-155]: https://emnify.atlassian.net/browse/SDOCS-155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ