### PR TITLE
Appropriately size footer tap targets to enhance mobile SEO

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -143,3 +143,10 @@
 .custom-details-example-json-response .collapsibleContent_i85q {
   border-top: 1px solid #000035 !important;
 }
+
+/* Footer links on smaller screens */
+@media screen and (max-width: 996px) {
+  .footer__link-item {
+    padding: 0.5rem 0;
+  }
+}


### PR DESCRIPTION
✨ _**TLDR: Increased the padding between footer links when displayed on smaller screens to increase mobile SEO-friendliness.**_

### Problem

Lighthouse flagged an SEO-issue on mobile for our footer link items: 

> **Tap targets are not appropriately sized**
> Interactive elements like buttons and links should be large enough (48x48px), and have enough space around them, to be easy enough to tap without overlapping onto other elements. [Learn more.](https://developer.chrome.com/docs/lighthouse/seo/tap-targets/)

<details>
<summary>Screenshot</summary>
<img width="600" alt="Screenshot 2023-01-12 at 13 33 46" src="https://user-images.githubusercontent.com/26869552/212167665-693abfae-cba4-419c-bda0-fd09b96651e8.png">
</details>

### Fix

Added a media query to `custom.css` that overrides the default padding at the specified breakpoint where the footer changes to a stacked view. 

👩🏼‍🎨 Visual preview

<img width="558" alt="Screenshot 2023-01-12 at 13 45 53" src="https://user-images.githubusercontent.com/26869552/212169727-29212bbf-fa23-4f1e-a5c9-ca09b8dda9db.png">
<img width="1512" alt="Screenshot 2023-01-12 at 13 51 12" src="https://user-images.githubusercontent.com/26869552/212169731-c21e5cc9-b4d7-44b5-808c-0d212d83fbca.png">

<details>
<summary>Full footer on smaller screen</summary>
<img width="754" alt="Screenshot 2023-01-12 at 13 52 05" src="https://user-images.githubusercontent.com/26869552/212169226-8c26e5ff-67da-4ae8-92d2-7a1ef8a6afd4.png">
<img width="754" alt="Screenshot 2023-01-12 at 13 52 14" src="https://user-images.githubusercontent.com/26869552/212169231-bd26b91a-c626-4610-b5dd-8933c1b60993.png">
</details>

Internal ticket 🎟️ [SDOCS-180](https://emnify.atlassian.net/browse/SDOCS-180)

[SDOCS-180]: https://emnify.atlassian.net/browse/SDOCS-180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ