### PR TITLE
Fix unsupported style property in docusaurus config

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -81,7 +81,7 @@ const config = {
         logo: {
           alt: "",
           src: "img/logo-icon-only-dark.svg",
-          style: { "margin-top": "1.5rem" },
+          style: { marginTop: "1.5rem" },
         },
         links: [
           {


### PR DESCRIPTION
### Problem

When running our `main` branch locally, I noticed we have this error:

<img width="592" alt="Screenshot 2023-01-12 at 21 48 59" src="https://user-images.githubusercontent.com/26869552/212234746-2342ecf8-eef8-4c89-85bb-41efbb3f51b7.png">

(my bad 😅 )

### Fix

Rewrite the style property so it's supported by React.