### PR TITLE
SDOCS-181-Quickstart-guide-content-change-requests

### DIFF
--- a/docs/quickstart/getting-started.md
+++ b/docs/quickstart/getting-started.md
@@ -19,7 +19,6 @@ Log into your [emnify account](https://portal.emnify.com) and follow these steps
 
 1. On the dashboard, click on order on **Get your FREE SIMs**
 1. Select the SIM cards of your choice.
-    - If you select physical SIM cards, you can further choose between 3in1 (no nano SIM) or 4in1 (with nano SIM).
-    - If you select the eSIM, you can directly download it into your eSIM compatible phone. You can find the instructions to do so in this [blog post](https://www.emnify.com/en/developer-hub/emnify-developer-esim).
-1. For the physical SIM cards, proceed to fill in your shipping details.
+You can choose between 3-in-1 (no nano SIM) or 4-in-1 (with nano SIM).
+1. Fill in your shipping details.
 1. Proceed to pay the shipping charges and you will be notified when the SIM cards will be shipped.

--- a/docs/quickstart/registering-sims.md
+++ b/docs/quickstart/registering-sims.md
@@ -12,8 +12,4 @@ The link includes the **BIC** (Batch Identification Code) of the card.
 Login to your [emnify account](https://portal.emnify.com).  
 On the dashboard, click the [**Register**](https://portal.emnify.com/sim-registration/single) link in the **Register your SIM cards** section.
 1. Enter the Batch Identification Code (**BIC** 1) in the prompt. You can find the BIC1 on the back of your SIM card.
-1. If you have ordered more than 5 SIM cards, you need to batch register them using the **BIC2**.  
-
-:::tip
-If you have a developer eSIM, the downloading process of an eSIM automatically registers it in our portal.
-:::
+1. If you have ordered more than 5 SIM cards, you need to batch register them using the **BIC2**.

--- a/docs/services/global-iot-sim.md
+++ b/docs/services/global-iot-sim.md
@@ -50,21 +50,6 @@ The following table shows comparisons to a standard consumer SIM.
 | Mechnical Shock Jedec JESD22-B104 | | | SA |
 | Low Power features | | •&nbsp;Poll Interval negotiation •&nbsp;UICC&nbsp;suspension and resume | •&nbsp;Poll Interval negotiation •&nbsp;UICC&nbsp;suspension and resume |
 
-## eSIM
-
-emnify offers an easy entry to test the services and platform by downloading an emnify eSIM profile to an eSIM compatible phone or tablet.
-During the trial period every organization has the option to download one profile which can be used instantly.
-
-The eSIM does not use a multi-IMSI applet (unlike the physical SIM cards) and therefore has some differences in the network coverage. 
-For a list of supported devices and limitations please refer to the [knowledge base](https://support.emnify.com/hc/en-us/articles/360021545600-Evaluation-eSIM-device-support-and-restrictions#h_01F7V2BVKT0RQRVXK3VNSPYQMW).
-
-The eSIM can be used to test and verify all emnify functionalities including:
-
-- Availability of networks
-- API functionality
-- Cloud Connect and Data Streamer integration
-- Zapier No-Code Integrations
-
 ## Multi-IMSI application
 
 emnify IoT SIM cards are equipped with a multi-IMSI applet that contains emnify’s as well as our partner operators' profiles. 


### PR DESCRIPTION
Removed the eSIM-specific content per the request we received:

“We don’t offer these eSIM for developers any more, so we should not make any reference to them, at all”

internal ticket 🎫 SDOCS-181