### PR TITLE
Sidebar enhancements: Auto-collapse categories and add hide option

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -80,6 +80,7 @@ const config = {
       docs: {
         sidebar: {
           hideable: true,
+          autoCollapseCategories: true
         },
       },
       footer: {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -77,6 +77,11 @@ const config = {
           src: "img/logo-word-blue-295x80.png",
         },
       },
+      docs: {
+        sidebar: {
+          hideable: true,
+        },
+      },
       footer: {
         logo: {
           alt: "",

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -144,6 +144,30 @@
   border-top: 1px solid #000035 !important;
 }
 
+/* Collapse sidebar button */
+
+button[title="Collapse sidebar"] {
+  border-top: none;
+}
+
+button[title="Collapse sidebar"]:hover {
+  background-color: #010D410F;
+}
+
+button[title="Collapse sidebar"] svg path {
+  fill: #000035;
+}
+
+/* Expand sidebar "button" */
+
+div[title="Expand sidebar"] svg path {
+  fill: #000035;
+}
+
+div[title="Expand sidebar"]:hover {
+  background-color: #010D410F;
+}
+
 /* Footer links on smaller screens */
 @media screen and (max-width: 996px) {
   .footer__link-item {


### PR DESCRIPTION
Some enhancements to our main docs sidebar ✨ 
- Make sidebar hideable so readers can focus on the content
- Enable auto-collapse on open categories when expanding another section 

📹 [Demo - Screen recording on Loom](https://www.loom.com/share/eb291acab0e548c7bf57f2eff065a790)

<details>
<summary>Screenshots of the new sidebar button</summary>
<img width="442" alt="Screenshot 2023-01-13 at 23 37 32" src="https://user-images.githubusercontent.com/26869552/212457748-9cd1181d-21ca-4157-995d-8ae6e371ddc9.png">
<img width="289" alt="Screenshot 2023-01-13 at 23 37 47" src="https://user-images.githubusercontent.com/26869552/212457749-5376234f-8bf6-4c2f-a8e7-0a19a6fcc628.png">
</details>

Internal ticket 🎫  [SDOCS-189](https://emnify.atlassian.net/browse/SDOCS-189)

[SDOCS-189]: https://emnify.atlassian.net/browse/SDOCS-189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ