### PR TITLE
Remove inaccurate FaaS information on Security page

### DIFF
--- a/docs/services/security.md
+++ b/docs/services/security.md
@@ -23,8 +23,6 @@ In this way, latency and data stability is improved, and the end customer can be
 - Cloud Access Security Broker (CASB)  
 emnify allows centrally defining policies for the devices such as: networks that can be accessed, allowed IP addresses through which authorized users can remotely access devices.
 All configuration is done in the central platform and applied wherever the device is.
-- Firewall as a Service (FaaS)  
-emnify provides a firewall as a Service which limits the IP addresses that are reachable for a device, making sure that the devices cannot be misused for other purposes.
 
 In the following sections we will discuss some of the security features offered by emnify.
 


### PR DESCRIPTION
Based on feedback received from Jean-Eudes (Team Lead Customer Success):

> please remove the wrong information like the part about SASE in the security: Firewall as a Service (FaaS)
emnify provides a firewall as a Service which limits the IP addresses that are reachable for a device, making sure that the devices cannot be misused for other purposes.

This PR removes it 🔥 

Internal ticket 🎫  [SDOCS-190](https://emnify.atlassian.net/browse/SDOCS-190)

[SDOCS-190]: https://emnify.atlassian.net/browse/SDOCS-190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ