### PR TITLE
Change navbar title from Developers to Documentation

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -71,7 +71,7 @@ const config = {
         disableSwitch: true
       },
       navbar: {
-        title: "Developers",
+        title: "Documentation",
         logo: {
           alt: "emnify Documentation – Home",
           src: "img/logo-word-blue-295x80.png",


### PR DESCRIPTION
Part of the feedback we received from Jorge (support):

> Also, one thing to consider here is that the standard emnify customer is not a developer, and in many cases is not technical at all. 

Given this information, and the fact that we decided to go with the `docs.emnify.com` subdomain, I've updated our navbar title to match.

✨ Visual preview
<img width="380" alt="Screenshot 2023-01-14 at 22 04 42" src="https://user-images.githubusercontent.com/26869552/212522500-d9d6277f-3903-4b98-8038-c19195dc48a6.png">

<details>
<summary>Current title</summary>
<img width="405" alt="Screenshot 2023-01-14 at 22 04 20" src="https://user-images.githubusercontent.com/26869552/212522510-3dededf3-3cae-4910-80e0-9adcc4e91cc6.png">
</details>

Internal ticket 🎫  [SDOCS-191](https://emnify.atlassian.net/browse/SDOCS-191)

[SDOCS-191]: https://emnify.atlassian.net/browse/SDOCS-191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ