### PR TITLE
Increase padding around main content on smaller screens

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -169,8 +169,22 @@ div[title="Expand sidebar"]:hover {
 }
 
 /* Footer links on smaller screens */
-@media screen and (max-width: 996px) {
+@media only screen and (max-width: 996px) {
   .footer__link-item {
     padding: 0.5rem 0;
+  }
+}
+
+/* Main content container padding */
+
+.container {
+  padding-left: 24px;
+  padding-right: 24px;
+}
+
+@media only screen and (max-width: 996px) {
+  .container {
+    padding-left: 20px;
+    padding-right: 20px;
   }
 }


### PR DESCRIPTION
Based on feedback we received from Aaron, I used some hacky CSS to increase the left and right side padding on the main content container. 

I opted for `24px` on larger screens and `20px` on smaller (currently the default is `16px` for all screen sizes).

✨ Random visual examples

<details>
<summary>iPhone XR</summary>
<img width="448" alt="Screenshot 2023-01-18 at 23 21 25" src="https://user-images.githubusercontent.com/26869552/213309083-c7272547-e327-4eed-9c14-812756392f67.png">
</details>

<details>
<summary>Surface Pro 7</summary>
<img width="986" alt="Screenshot 2023-01-18 at 23 19 37" src="https://user-images.githubusercontent.com/26869552/213309531-4aa8b432-5abe-4652-8aa2-2563fc49430b.png">
</details>

<details>
<summary>My screen (13" Macbook Pro)</summary>
<img width="1509" alt="Screenshot 2023-01-18 at 23 16 55" src="https://user-images.githubusercontent.com/26869552/213309607-4f00a29a-0931-420e-9b2b-0ab8ae1c0327.png">
</details>

🧼 Bonus cleanup: Added a missing `only` to the other media query

Internal ticket 🎟️ [SDOCS-194](https://emnify.atlassian.net/browse/SDOCS-194)

[SDOCS-194]: https://emnify.atlassian.net/browse/SDOCS-194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ