### PR TITLE
Fix error in Teltonika GPS APN configuration command

### DIFF
--- a/docs/quickstart/devices/gps-trackers.md
+++ b/docs/quickstart/devices/gps-trackers.md
@@ -40,6 +40,10 @@ Otherwise, if there's no username or password configured, use the following:
 The two leading spaces are required.
 :::
 
+:::info
+Refer to the [Teltonika FMB Device Family Parameter list](https://wiki.teltonika-gps.com/view/Template:FMB_Device_Family_Parameter_list) for all available parameters.
+:::
+
 ## Ruptela GPS APN configuration
 
 *Applies to HCV5, LCV5, Pro5, Trace5/NA, FM-Tco4 HCV/HCV 3G, FM-Tco4 LCV/LCV 3G, FM-Pro4/Pro4 3G, FM-Eco4/4+, FM-Eco4 light/light+/3G, FM-Eco4 S Series, FM-Eco4 T Series, FM-Plug4*

--- a/docs/quickstart/devices/gps-trackers.md
+++ b/docs/quickstart/devices/gps-trackers.md
@@ -4,7 +4,7 @@ description: Configuring the APN for the most common GPS vendors
 # GPS trackers
 
 :::info
-For GPS vendors that aren't listed, please consult the respective manual and configure the APN to be `em` or `emnify`.
+For GPS vendors that aren't listed, please consult their respective manual and configure the APN to be `em` or `emnify`.
 :::
 
 ## Teltonika GPS APN configuration

--- a/docs/quickstart/devices/gps-trackers.md
+++ b/docs/quickstart/devices/gps-trackers.md
@@ -66,7 +66,7 @@ The SMS command to set the APN for Ruptela GPS trackers is:
 ```
 
 The \[SMSpassword\] can be set up in the Ruptela device center.
-If it isn't set, you can omit the SMSpassword, and the command is:
+If the SMSpassword isn't set, the command is:
 
 ```
 setconnection em
@@ -90,7 +90,7 @@ The SMS command to set the APN for Concox GPS trackers is:
 APN em#
 ```
 
-For some Concox models (e.g., TR02), the password needs to be sent with the command:
+For some Concox models, for instance TR02, the password needs to be sent with the command:
 
 ```
 APN,666666,em#

--- a/docs/quickstart/devices/gps-trackers.md
+++ b/docs/quickstart/devices/gps-trackers.md
@@ -3,7 +3,9 @@ description: Configuring the APN for the most common GPS vendors
 ---
 # GPS trackers
 
-For other GPS vendors, please consult the manual and configure the APN to be `em` or `emnify`.
+:::info
+For GPS vendors that aren't listed, please consult the respective manual and configure the APN to be `em` or `emnify`.
+:::
 
 ## Teltonika GPS APN configuration
 
@@ -14,8 +16,8 @@ For other GPS vendors, please consult the manual and configure the APN to be `em
 Configuring the APN for Teltonika GPS trackers can be done through:
 
 1. Teltonika Configurator over a USB, Bluetooth connection
-1. Via the SMS console through the emnify Portal
-1. Via the emnify SMS API or Zapier Integration (when automating the configuration)
+1. Via the SMS console through the [emnify Portal](https://portal.emnify.com/)
+1. Via the [emnify SMS API](https://cdn.emnify.net/api/doc/swagger.html#/Endpoint) or [Zapier Integration](https://zapier.com/apps/emnify/integrations/sms) (when automating the configuration)
 
 Newer Teltonika GPS versions automatically detect the emnify APN setting.
 
@@ -47,8 +49,8 @@ The two leading spaces are required.
 Configuring the APN for Ruptela GPS trackers can be done through:
 
 1. Ruptela Device Center over a USB, Bluetooth connection
-1. Via the SMS console through the emnify Portal
-1. via the emnify SMS API or Zapier Integration (when automating the configuration)
+1. Via the SMS console through the [emnify Portal](https://portal.emnify.com/)
+1. Via the [emnify SMS API](https://cdn.emnify.net/api/doc/swagger.html#/Endpoint) or [Zapier Integration](https://zapier.com/apps/emnify/integrations/sms) (when automating the configuration)
 
 When the GPS tracker is turned on for the first time after the SIM is installed, it shows the status **Attached** in the emnify Portal.
 At this point the device can receive SMS but not establish a data session unless the APN is setup or detected.
@@ -72,8 +74,8 @@ setconnection em
 
 Configuring the APN for Concox GPS trackers can be done:
 
-1. Via the SMS console through the emnify Portal 
-1. Via the emnify SMS API or Zapier Integration (when automating the configuration)
+1. Via the SMS console through the [emnify Portal](https://portal.emnify.com/)
+1. Via the [emnify SMS API](https://cdn.emnify.net/api/doc/swagger.html#/Endpoint) or [Zapier Integration](https://zapier.com/apps/emnify/integrations/sms) (when automating the configuration)
 
 When the GPS tracker is turned on for the first time after the SIM is installed, it shows the status **Attached** in the emnify Portal.
 At this point, the device can receive SMS but not establish a data session unless the APN is set up.
@@ -84,11 +86,15 @@ The SMS command to set the APN for Concox GPS trackers is:
 APN em#
 ```
 
-For some Concox models (e.g. TR02) the password (default `666666`) needs to be sent with the command:
+For some Concox models (e.g., TR02), the password needs to be sent with the command:
 
 ```
 APN,666666,em#
 ```
+
+:::note
+The default password is `666666`.
+:::
 
 ## Coban GPS APN configuration
 
@@ -96,8 +102,8 @@ APN,666666,em#
 
 Configuring the APN for Coban GPS trackers can be done:
 
-1. Via the SMS console through the emnify Portal
-1. Via the emnify SMS API or Zapier Integration (when automating the configuration)
+1. Via the SMS console through the [emnify Portal](https://portal.emnify.com/)
+1. Via the [emnify SMS API](https://cdn.emnify.net/api/doc/swagger.html#/Endpoint) or [Zapier Integration](https://zapier.com/apps/emnify/integrations/sms) (when automating the configuration)
 
 When the GPS tracker is turned on for the first time after the SIM is installed, it shows the status **Attached** in the emnify Portal.
 At this point, the device can receive SMS but not establish a data session unless the APN is set up and the GPRS service is activated.
@@ -114,8 +120,13 @@ The SMS command to set the APN for Coban GPS trackers is:
 APN[your_password] em
 ```
 
+:::caution
+There are no spaces between `gprs`/`APN` and the password.
+:::
+
+:::note
 The default password is `123456`.
-There are no spaces between gprs/APN and the password.
+:::
 
 ## Meitrack GPS APN configuration
 
@@ -124,8 +135,8 @@ There are no spaces between gprs/APN and the password.
 Configuring the APN for Meitrack GPS trackers can be done:
 
 1. Via the Meitrack manager
-1. Via the SMS console through the emnify Portal
-1. Via the emnify SMS API or Zapier Integration (when automating the configuration)
+1. Via the SMS console through the [emnify Portal](https://portal.emnify.com/)
+1. Via the [emnify SMS API](https://cdn.emnify.net/api/doc/swagger.html#/Endpoint) or [Zapier Integration](https://zapier.com/apps/emnify/integrations/sms) (when automating the configuration)
 
 When the GPS tracker is turned on for the first time after the SIM is installed, it shows the status **Attached** in the emnify Portal.
 At this point, the device can receive SMS but not establish a data session unless the APN is set up.
@@ -136,7 +147,9 @@ The SMS command to set the APN for Meitrack GPS trackers is:
 0000,A81,em,,
 ```
 
-Where `0000` is the default SMS password.
+:::note
+`0000` is the default SMS password.
+:::
 
 On other devices, the APN setting is done via the `A21` command:
 
@@ -144,16 +157,20 @@ On other devices, the APN setting is done via the `A21` command:
 666888,A21,1,server.meigps.com,8800,em,,
 ```
 
-Where `666888` is the default super password (not the SMS password).
+:::note
+`666888` is the default super password (not the SMS password).
+:::
 
+:::info
 Both SMS and super password can be changed and would then need to be replaced in the SMS command.
+:::
 
 ## Elinz GPS APN configuration
 
 Configuring the APN for Elinz GPS trackers can be done:
 
-1. Via the SMS console through the emnify Portal 
-1. Via the emnify SMS API or Zapier Integration (when automating the configuration)
+1. Via the SMS console through the [emnify Portal](https://portal.emnify.com/) 
+1. Via the [emnify SMS API](https://cdn.emnify.net/api/doc/swagger.html#/Endpoint) or [Zapier Integration](https://zapier.com/apps/emnify/integrations/sms) (when automating the configuration)
 
 When the GPS tracker is turned on for the first time after the SIM is installed, it shows the status **Attached** in the emnify Portal.
 At this point, the device can receive SMS but not establish a data session unless the APN is set up.
@@ -170,14 +187,16 @@ On other models, the APN configuration is a little different:
 apn[password] em
 ```
 
-Default password `123456`.
+:::note
+The default password is `123456`.
+:::
 
 ## Reachfar GPS APN configuration
 
 Configuring the APN for Reachfar GPS trackers can be done:
 
-1. Via the SMS console through the emnify Portal
-1. Via the emnify SMS API or Zapier Integration (when automating the configuration)
+1. Via the SMS console through the [emnify Portal](https://portal.emnify.com/)
+1. Via the [emnify SMS API](https://cdn.emnify.net/api/doc/swagger.html#/Endpoint) or [Zapier Integration](https://zapier.com/apps/emnify/integrations/sms) (when automating the configuration)
 
 When the GPS tracker is turned on for the first time after the SIM is installed, it shows the status **Attached** in the emnify Portal. 
 At this point, the device can receive SMS but not establish a data session
@@ -192,8 +211,11 @@ The following two SMS commands need to send:
 apn,em,plmn,90143#  // Send this SMS from the phone
 ```
 
+:::note
 `123456` is the default SMS password.
-After setting the APN the GPS tracker needs to be rebooted.
+:::
+
+After setting the APN, the GPS tracker needs to be rebooted.
 
 *Applies to RF-V26, RF-V26+, RF-V28, RF-V30, RF-V32, RF-V34, RF-V36, RF-V36, RF-V38, RF-V40, RF-V42, RF-V43，RF-V44, RF-V46*
 
@@ -204,14 +226,16 @@ pw,123456,center,[yourphonenumber]# // Bind tracker to specific phone.
 apn,em# // Send this SMS from the phone
 ```
 
+:::note
 `123456` is the default password.
+:::
 
 ## Queclink GPS APN configuration
 
 Configuring the APN for Queclink GPS trackers can be done:
 
-1. Via the SMS console through the emnify Portal
-1. Via the emnify SMS API or Zapier Integration (when automating the configuration)
+1. Via the SMS console through the [emnify Portal](https://portal.emnify.com/)
+1. Via the [emnify SMS API](https://cdn.emnify.net/api/doc/swagger.html#/Endpoint) or Zapier Integration (when automating the configuration)
 
 When the GPS tracker is turned on for the first time after the SIM is installed, it shows the status **Attached** in the emnify Portal.
 At this point, the device can receive SMS but not establish a data session unless the APN is set up.
@@ -219,15 +243,19 @@ At this point, the device can receive SMS but not establish a data session unles
 The SMS command to set the APN for Queclink GPS trackers is:
 
 ```
-AT+GTBSI=[password],em,,,,,,,0002$ // The password default is device model, e.g., gl200
+AT+GTBSI=[password],em,,,,,,,0002$
 ```
+
+:::note
+The default password is the device model (e.g., `gl200`).
+:::
 
 ## Bitrek GPS APN configuration
 
 Configuring the APN for Bitrek GPS trackers can be done:
 
-1. Via the SMS console through the emnify Portal
-1. Via the emnify SMS API or Zapier Integration (when automating the configuration)
+1. Via the SMS console through the [emnify Portal](https://portal.emnify.com/)
+1. Via the [emnify SMS API](https://cdn.emnify.net/api/doc/swagger.html#/Endpoint) or [Zapier Integration](https://zapier.com/apps/emnify/integrations/sms) (when automating the configuration)
 
 When the GPS tracker is turned on for the first time after the SIM is installed, it shows the status **Attached** in the emnify Portal.
 At this point, the device can receive SMS but not establish a data session unless the APN is set up.
@@ -242,8 +270,8 @@ The Bitrek GPS tracker also utilizes a roaming command (`setparam 0917`) togethe
 The following SMS commands need to be send:
 
 ```
-setparam 0917 1 // enable romaing in all networks as defined in the next SMS
-setparam 0020 <MNC> // MNC is the mobile network code on which the device shall roam
+setparam 0917 1 // enables roaming in all networks as defined in the following SMS
+setparam 0020 <MNC> // Mobile network code (MNC) that the device will roam on
 setparam 0021 <MNC>
 ....
 setparam 0099 <MNC>

--- a/docs/quickstart/devices/gps-trackers.md
+++ b/docs/quickstart/devices/gps-trackers.md
@@ -17,12 +17,18 @@ Configuring the APN for Teltonika GPS trackers can be done through:
 1. Via the SMS console through the emnify Portal
 1. Via the emnify SMS API or Zapier Integration (when automating the configuration)
 
-Newer Teltonika GPS versions automatically detect the emnify APN setting
+Newer Teltonika GPS versions automatically detect the emnify APN setting.
 
 When the GPS tracker is turned on for the first time after the SIM is installed, it shows the status **Attached** in the emnify Portal.
 At this point, the device can receive SMS but not establish a data session unless the APN is set up or detected.
 
-The SMS command to set the APN is:
+If you've set a username and password for the device, use the following SMS command to set the APN (replacing `USERNAME` and `PASSWORD` with your credentials):
+
+```
+USERNAME PASSWORD setparam 2001:em
+```
+
+Otherwise, if there's no username or password configured, use the following:
 
 ```
   setparam 2001:em
@@ -38,13 +44,13 @@ The two leading spaces are required.
 
 [Source Ruptela Documentation](https://doc.ruptela.lt/display/AB/Tracking+devices)
 
-Configuring the APN for Ruptela GPS trackers can be done through
+Configuring the APN for Ruptela GPS trackers can be done through:
 
 1. Ruptela Device Center over a USB, Bluetooth connection
-1. Via the SMS console through the emnify Portal (most simple)
+1. Via the SMS console through the emnify Portal
 1. via the emnify SMS API or Zapier Integration (when automating the configuration)
 
-When the GPS tracker is turned on for the first time after the SIM is installed it is showing the status `Attached` in the emnify portal.
+When the GPS tracker is turned on for the first time after the SIM is installed, it shows the status **Attached** in the emnify Portal.
 At this point the device can receive SMS but not establish a data session unless the APN is setup or detected.
 
 The SMS command to set the APN for Ruptela GPS trackers is:
@@ -53,8 +59,8 @@ The SMS command to set the APN for Ruptela GPS trackers is:
 [SMSpassword] setconnection em
 ```
 
-The \[SMSpassword\] can be setup in the Ruptela device center.
-If it is not set then the SMSpassword can be omitted and the command is only
+The \[SMSpassword\] can be set up in the Ruptela device center.
+If it isn't set, you can omit the SMSpassword, and the command is:
 
 ```
 setconnection em
@@ -62,8 +68,7 @@ setconnection em
 
 ## Concox GPS APN configuration
 
-*Applies to JM-VL01, JM-VL02, JM-BL11, JM-VL03, JM-VL04, JM-LL01,
-JM-LL02, JM-LL301, X3,Wetrack140, Wetrack2, Wetrack lite, Bl10, GT06N, OB22, ET25, HVT001, EG02, JM-VG01U, JM-VG02U, JM-VG04Q, AT1-AT6, CT10, JM-LG01, JM-LG05, TBT100*
+*Applies to JM-VL01, JM-VL02, JM-BL11, JM-VL03, JM-VL04, JM-LL01, JM-LL02, JM-LL301, X3,Wetrack140, Wetrack2, Wetrack lite, Bl10, GT06N, OB22, ET25, HVT001, EG02, JM-VG01U, JM-VG02U, JM-VG04Q, AT1-AT6, CT10, JM-LG01, JM-LG05, TBT100*
 
 Configuring the APN for Concox GPS trackers can be done:
 
@@ -79,7 +84,7 @@ The SMS command to set the APN for Concox GPS trackers is:
 APN em#
 ```
 
-For some Concox models (e.g. TR02) the password (default `666666`) needs to be send\t with the command:
+For some Concox models (e.g. TR02) the password (default `666666`) needs to be sent with the command:
 
 ```
 APN,666666,em#
@@ -133,7 +138,7 @@ The SMS command to set the APN for Meitrack GPS trackers is:
 
 Where `0000` is the default SMS password.
 
-On other devices the APN setting is done via the `A21` command:
+On other devices, the APN setting is done via the `A21` command:
 
 ```
 666888,A21,1,server.meigps.com,8800,em,,
@@ -183,11 +188,11 @@ unless the APN is set up.
 The following two SMS commands need to send:
 
 ```
-123456,sos1,[yourphonenumber]# // Bind the tracker to a specific phone number e.g. 49173871878 (instead of +49173871878). 123456 is the default SMS password.
+123456,sos1,[yourphonenumber]# // Bind the tracker to a specific phone number (e.g., 49173871878 instead of +49173871878).
 apn,em,plmn,90143#  // Send this SMS from the phone
 ```
 
-`123456` is the default password.
+`123456` is the default SMS password.
 After setting the APN the GPS tracker needs to be rebooted.
 
 *Applies to RF-V26, RF-V26+, RF-V28, RF-V30, RF-V32, RF-V34, RF-V36, RF-V36, RF-V38, RF-V40, RF-V42, RF-V43，RF-V44, RF-V46*
@@ -195,9 +200,11 @@ After setting the APN the GPS tracker needs to be rebooted.
 The following two SMS commands need to send:
 
 ```
-pw,123456,center,[yourphonenumber]# // Bind tracker to specific phone. 123456 is the default password.
+pw,123456,center,[yourphonenumber]# // Bind tracker to specific phone.
 apn,em# // Send this SMS from the phone
 ```
+
+`123456` is the default password.
 
 ## Queclink GPS APN configuration
 


### PR DESCRIPTION
During our feedback session with Jorge, he mentioned that there's an error in the Teltonika GPS APN configuration setup command:

> the command is: Username (space) password (space)setparam 2001:em. If the devices do not have a username and password set, then it is the two leading spaces

So updated that and, as a bonus, I also cleaned up some of the grammar and formatting on this page 🧼 

✨ Visual preview

<details>
<summary>Currently published</summary>
<img width="724" alt="Screenshot 2023-01-19 at 21 43 31" src="https://user-images.githubusercontent.com/26869552/213566448-ca22b1e1-ca91-4815-b3e5-0eb39b6fa988.png">
</details>
</details>

<details>
<summary>After this PR</summary>
<img width="724" alt="Screenshot 2023-01-19 at 21 43 31" src="https://user-images.githubusercontent.com/26869552/213566179-77ea2371-ab5a-408e-a90d-38e6b30dfc3f.png">
</details>