### PR TITLE
Add OneTrust consent and cookie management

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -39,6 +39,27 @@ const config = {
     ],
   ],
 
+  scripts: [
+    {
+      type: 'text/javascript',
+      src: 'https://cdn.cookielaw.org/consent/0c5a33bc-8e12-407d-937d-4e4c9f6e86a0/OtAutoBlock.js',
+      defer: true
+    },
+    {
+      src: 'https://cdn.cookielaw.org/scripttemplates/otSDKStub.js',
+      'data-document-language': true,
+      type: 'text/javascript',
+      charset: 'UTF-8',
+      'data-domain-script': '0c5a33bc-8e12-407d-937d-4e4c9f6e86a0',
+      defer: true
+    },
+    {
+      type: 'text/javascript',
+      src: '/scripts/optanonWrapper.js',
+      defer: true 
+    }
+  ],
+
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
@@ -87,7 +108,7 @@ const config = {
         logo: {
           alt: "",
           src: "img/logo-icon-only-dark.svg",
-          style: { marginTop: "1.5rem" },
+          style: { marginTop: "0.5rem" },
         },
         links: [
           {
@@ -139,6 +160,13 @@ const config = {
               {
                 label: "Privacy policy",
                 href: "https://www.emnify.com/privacy-policy"
+              },
+              {
+                html: `
+                <button style="visibility:hidden;" id="ot-sdk-btn" class="ot-sdk-show-settings">
+                  Cookie Settings
+                </button>
+              `,
               }
             ]
           },

--- a/static/scripts/optanonWrapper.js
+++ b/static/scripts/optanonWrapper.js
@@ -1,0 +1,1 @@
+function OptanonWrapper() { }


### PR DESCRIPTION
### Description

Added OneTrust consent and cookie management to ensure our docs are GDPR compliant 🍪 
- Implemented based on the scripts sent by Ben from Marketing
- Verified that the keys aren't private
- Popup and settings button function the same as the emnify.com website 

Next steps: Add the following scripts 🛸 
- Google Tag Manager (#62)
- Jentis Tag Manager (#62)
- Heap (#61)

### ✨ Visual preview

<details>
<summary>Cookie popup</summary>
<img width="800" alt="Screenshot 2023-01-23 at 12 12 02" src="https://user-images.githubusercontent.com/26869552/214026797-45a8247c-ca4c-4b3e-bd58-b4974e513959.png">
</details>

<details>
<summary>Settings button</summary>
<img width="800" alt="Screenshot 2023-01-23 at 12 12 34" src="https://user-images.githubusercontent.com/26869552/214026906-64a8e477-6e34-4b34-a1f5-325dbb97dec8.png">
</details>

### Additional Context

_**Internal tickets**_ 🎟️ 
Parent task: [SDOCS-159](https://emnify.atlassian.net/browse/SDOCS-159)
OneTrust subtask: [SDOCS-217](https://emnify.atlassian.net/browse/SDOCS-217)

[SDOCS-159]: https://emnify.atlassian.net/browse/SDOCS-159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[SDOCS-217]: https://emnify.atlassian.net/browse/SDOCS-217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ