### PR TITLE
Implement Google Tag Manager and JENTIS Tag Manager scripts

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -61,6 +61,13 @@ const config = {
     {
       type: 'text/javascript',
       src: '/scripts/heapAnalytics.js',
+    },
+    {
+      src: '/scripts/googleTagManager.js',
+      async: true
+    },
+    {
+      src: '/scripts/jentisTagManager.js'
     }
   ],
 

--- a/static/scripts/googleTagManager.js
+++ b/static/scripts/googleTagManager.js
@@ -1,0 +1,15 @@
+setTimeout(function () {
+  (function (w, d, s, l, i) {
+    w[l] = w[l] || [];
+    w[l].push({
+      "gtm.start": new Date().getTime(),
+      event: "gtm.js",
+    });
+    var f = d.getElementsByTagName(s)[0],
+      j = d.createElement(s),
+      dl = l != "dataLayer" ? "&l=" + l : "";
+    j.async = true;
+    j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
+    f.parentNode.insertBefore(j, f);
+  })(window, document, "script", "dataLayer", "GTM-PPFMTR");
+}, 3500);

--- a/static/scripts/jentisTagManager.js
+++ b/static/scripts/jentisTagManager.js
@@ -1,0 +1,25 @@
+(function (sCDN,sCDNProject,sCDNWorkspace,sCDNVers) {
+    if(
+        window.localStorage !== null &&
+        typeof window.localStorage === "object" &&
+        typeof window.localStorage.getItem === "function" &&
+        window.sessionStorage !== null &&
+        typeof window.sessionStorage === "object" &&
+        typeof window.sessionStorage.getItem === "function" )
+    {
+        sCDNVers = window.sessionStorage.getItem('jts_preview_version') || window.localStorage.getItem('jts_preview_version') || sCDNVers;
+    }
+    window.jentis = window.jentis || {};
+    window.jentis.config = window.jentis.config || {};
+    window.jentis.config.frontend = window.jentis.config.frontend || {};
+    window.jentis.config.frontend.cdnhost = sCDN+"/get/"+sCDNWorkspace+"/web/"+sCDNVers+"/";
+    window.jentis.config.frontend.vers = sCDNVers;
+    window.jentis.config.frontend.env = sCDNWorkspace;
+    window.jentis.config.frontend.project = sCDNProject;
+    window._jts = window._jts || [];
+    var f   = document.getElementsByTagName("script")[0];
+    var j = document.createElement("script");
+    j.async = true;
+    j.src   = window.jentis.config.frontend.cdnhost+"v1mf8j.js";
+    f.parentNode.insertBefore(j, f)
+})("https://fuuaay.emnify.com","emnify","live","_");


### PR DESCRIPTION
Blocked by #58 🍪 Related to #61 

### Description

Ben from Marketing provided scripts for Google Tag Manager and JENTIS Tag Manager scripts. Also confirmed with him that none of the data within the script is confidential.

🌐 Once the subdomain is live, we'll also need to add an entry to the DNS for JENTIS Tag Manager (the subdomain will be the main communication channel JENTIS uses).

### Additional Context

🎟️  _Internal tickets_ 🎟️ 
- Parent task: [SDOCS-159](https://emnify.atlassian.net/browse/SDOCS-159)
- Google Tag Manager: [SDOCS-215](https://emnify.atlassian.net/browse/SDOCS-215)
- Jentis Tag Manager: [SDOCS-216](https://emnify.atlassian.net/browse/SDOCS-216)


[SDOCS-159]: https://emnify.atlassian.net/browse/SDOCS-159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SDOCS-215]: https://emnify.atlassian.net/browse/SDOCS-215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SDOCS-216]: https://emnify.atlassian.net/browse/SDOCS-216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ