### PR TITLE
Update event types page ToC to show all events

### DIFF
--- a/docs/services/events/event-types.md
+++ b/docs/services/events/event-types.md
@@ -1,6 +1,5 @@
 ---
 description: List of all available event types
-toc_max_heading_level: 2
 ---
 
 # Event types


### PR DESCRIPTION
### Description

When the Portal squad devs reviewed the [Event Types page](https://emnify.github.io/product-docs/services/events/event-types), Martin (backend engineer) mentioned in his feedback:

> maybe a complete list at the beginning with links would be nice. when i just want to see what possibilities are there.

Originally when building this page, I thought only limiting the ToC to the use case headers would help keep it clean - but after hearing the feedback, I realized that we're limiting how accessible the content is for readers. 

In this PR, I've removed the maximum heading level on the ToC so now all of the events are shown 🕺🏼 

### ✨ Visual preview 

**Full desktop view**
<img width="1071" alt="Screenshot 2023-01-25 at 14 36 31" src="https://user-images.githubusercontent.com/26869552/214579334-a06dd829-ebd5-4836-9723-da3db544e551.png">

**Smaller screen**
<img width="495" alt="Screenshot 2023-01-25 at 14 37 04" src="https://user-images.githubusercontent.com/26869552/214579345-331d5fc9-56fa-41f8-8214-891b3d1a9205.png">

