### PR TITLE
Create CNAME

### DIFF
--- a/static/CNAME
+++ b/static/CNAME
@@ -1,0 +1,1 @@
+docs.emnify.com


### PR DESCRIPTION
### Description

Added a CNAME file to our `static` directory, as recommended by the [Docusaurus docs](https://docusaurus.io/docs/deployment#deploying-to-github-pages):

> In case you want to use your custom domain for GitHub Pages, create a `CNAME` file in the `static` directory. Anything within the `static` directory will be copied to the root of the `build` directory for deployment.

### Background

We didn't add a CNAME file in #52 because [the GitHub docs](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/troubleshooting-custom-domains-and-github-pages#cname-errors) stated that CNAME files are ignored and not required when publishing from a custom GitHub Action workflow. 

However, despite adding the custom domain via this repo's settings page and it properly creating a CNAME file on our publishing branch (`gh-pages`), our workflows were overwriting this and our beautiful subdomain was serving a 404 💀 

### Additional Context

Docs team can follow [this whole discovery journey in Slack](https://emnifyteam.slack.com/archives/C04DQCD4G5R/p1675077666939379?thread_ts=1675075800.757799&cid=C04DQCD4G5R) 😂 
