### PR TITLE
Use deep links to the emnify Portal where possible

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -25,7 +25,7 @@ Gives information about the registration status and access technology of the ser
 A part of [GSM](#gsm---global-system-for-mobile-communications) infrastructure, validates any SIM card attempting network connection when a phone has a live network signal.
 
 ## BIC - Batch identification code  
-A unique code for ordered SIM cards used to register the SIM cards on the [emnify Portal](https://portal.emnify.com/sim-inventory).
+A unique code for ordered SIM cards used to register the SIM cards on the [**SIM Inventory** page of the emnify Portal](https://portal.emnify.com/sim-inventory).
 
 ## Callback URL  
 URL that will be called by a service to send and receive data related to an event that caused this action.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -25,7 +25,7 @@ Gives information about the registration status and access technology of the ser
 A part of [GSM](#gsm---global-system-for-mobile-communications) infrastructure, validates any SIM card attempting network connection when a phone has a live network signal.
 
 ## BIC - Batch identification code  
-A unique code for ordered SIM cards used to register the SIM cards on the [emnify Portal](https://portal.emnify.com/).
+A unique code for ordered SIM cards used to register the SIM cards on the [emnify Portal](https://portal.emnify.com/sim-inventory).
 
 ## Callback URL  
 URL that will be called by a service to send and receive data related to an event that caused this action.

--- a/docs/quickstart/devices/gps-trackers.md
+++ b/docs/quickstart/devices/gps-trackers.md
@@ -16,7 +16,7 @@ For GPS vendors that aren't listed, please consult their respective manual and c
 Configuring the APN for Teltonika GPS trackers can be done through:
 
 1. Teltonika Configurator over a USB, Bluetooth connection
-1. Via the SMS console through the [emnify Portal](https://portal.emnify.com/connected-devices)
+1. Via the SMS console through the [**Connected Devices** page of the emnify Portal](https://portal.emnify.com/connected-devices)
 1. Via the [emnify SMS API](https://cdn.emnify.net/api/doc/swagger.html#/Endpoint) or [Zapier Integration](https://zapier.com/apps/emnify/integrations/sms) (when automating the configuration)
 
 Newer Teltonika GPS versions automatically detect the emnify APN setting.
@@ -53,7 +53,7 @@ Refer to the [Teltonika FMB Device Family Parameter list](https://wiki.teltonika
 Configuring the APN for Ruptela GPS trackers can be done through:
 
 1. Ruptela Device Center over a USB, Bluetooth connection
-1. Via the SMS console through the [emnify Portal](https://portal.emnify.com/connected-devices)
+1. Via the SMS console through the [**Connected Devices** page of the emnify Portal](https://portal.emnify.com/connected-devices)
 1. Via the [emnify SMS API](https://cdn.emnify.net/api/doc/swagger.html#/Endpoint) or [Zapier Integration](https://zapier.com/apps/emnify/integrations/sms) (when automating the configuration)
 
 When the GPS tracker is turned on for the first time after the SIM is installed, it shows the status **Attached** in the emnify Portal.
@@ -78,7 +78,7 @@ setconnection em
 
 Configuring the APN for Concox GPS trackers can be done:
 
-1. Via the SMS console through the [emnify Portal](https://portal.emnify.com/connected-devices)
+1. Via the SMS console through the [**Connected Devices** page of the emnify Portal](https://portal.emnify.com/connected-devices)
 1. Via the [emnify SMS API](https://cdn.emnify.net/api/doc/swagger.html#/Endpoint) or [Zapier Integration](https://zapier.com/apps/emnify/integrations/sms) (when automating the configuration)
 
 When the GPS tracker is turned on for the first time after the SIM is installed, it shows the status **Attached** in the emnify Portal.
@@ -106,7 +106,7 @@ The default password is `666666`.
 
 Configuring the APN for Coban GPS trackers can be done:
 
-1. Via the SMS console through the [emnify Portal](https://portal.emnify.com/connected-devices)
+1. Via the SMS console through the [**Connected Devices** page of the emnify Portal](https://portal.emnify.com/connected-devices)
 1. Via the [emnify SMS API](https://cdn.emnify.net/api/doc/swagger.html#/Endpoint) or [Zapier Integration](https://zapier.com/apps/emnify/integrations/sms) (when automating the configuration)
 
 When the GPS tracker is turned on for the first time after the SIM is installed, it shows the status **Attached** in the emnify Portal.
@@ -139,7 +139,7 @@ The default password is `123456`.
 Configuring the APN for Meitrack GPS trackers can be done:
 
 1. Via the Meitrack manager
-1. Via the SMS console through the [emnify Portal](https://portal.emnify.com/connected-devices)
+1. Via the SMS console through the [**Connected Devices** page of the emnify Portal](https://portal.emnify.com/connected-devices)
 1. Via the [emnify SMS API](https://cdn.emnify.net/api/doc/swagger.html#/Endpoint) or [Zapier Integration](https://zapier.com/apps/emnify/integrations/sms) (when automating the configuration)
 
 When the GPS tracker is turned on for the first time after the SIM is installed, it shows the status **Attached** in the emnify Portal.
@@ -173,7 +173,7 @@ Both SMS and super password can be changed and would then need to be replaced in
 
 Configuring the APN for Elinz GPS trackers can be done:
 
-1. Via the SMS console through the [emnify Portal](https://portal.emnify.com/connected-devices) 
+1. Via the SMS console through the [**Connected Devices** page of the emnify Portal](https://portal.emnify.com/connected-devices) 
 1. Via the [emnify SMS API](https://cdn.emnify.net/api/doc/swagger.html#/Endpoint) or [Zapier Integration](https://zapier.com/apps/emnify/integrations/sms) (when automating the configuration)
 
 When the GPS tracker is turned on for the first time after the SIM is installed, it shows the status **Attached** in the emnify Portal.
@@ -199,7 +199,7 @@ The default password is `123456`.
 
 Configuring the APN for Reachfar GPS trackers can be done:
 
-1. Via the SMS console through the [emnify Portal](https://portal.emnify.com/connected-devices)
+1. Via the SMS console through the [**Connected Devices** page of the emnify Portal](https://portal.emnify.com/connected-devices)
 1. Via the [emnify SMS API](https://cdn.emnify.net/api/doc/swagger.html#/Endpoint) or [Zapier Integration](https://zapier.com/apps/emnify/integrations/sms) (when automating the configuration)
 
 When the GPS tracker is turned on for the first time after the SIM is installed, it shows the status **Attached** in the emnify Portal. 
@@ -238,7 +238,7 @@ apn,em# // Send this SMS from the phone
 
 Configuring the APN for Queclink GPS trackers can be done:
 
-1. Via the SMS console through the [emnify Portal](https://portal.emnify.com/connected-devices)
+1. Via the SMS console through the [**Connected Devices** page of the emnify Portal](https://portal.emnify.com/connected-devices)
 1. Via the [emnify SMS API](https://cdn.emnify.net/api/doc/swagger.html#/Endpoint) or Zapier Integration (when automating the configuration)
 
 When the GPS tracker is turned on for the first time after the SIM is installed, it shows the status **Attached** in the emnify Portal.
@@ -258,7 +258,7 @@ The default password is the device model (e.g., `gl200`).
 
 Configuring the APN for Bitrek GPS trackers can be done:
 
-1. Via the SMS console through the [emnify Portal](https://portal.emnify.com/connected-devices)
+1. Via the SMS console through the [**Connected Devices** page of the emnify Portal](https://portal.emnify.com/connected-devices)
 1. Via the [emnify SMS API](https://cdn.emnify.net/api/doc/swagger.html#/Endpoint) or [Zapier Integration](https://zapier.com/apps/emnify/integrations/sms) (when automating the configuration)
 
 When the GPS tracker is turned on for the first time after the SIM is installed, it shows the status **Attached** in the emnify Portal.

--- a/docs/quickstart/devices/gps-trackers.md
+++ b/docs/quickstart/devices/gps-trackers.md
@@ -16,7 +16,7 @@ For GPS vendors that aren't listed, please consult their respective manual and c
 Configuring the APN for Teltonika GPS trackers can be done through:
 
 1. Teltonika Configurator over a USB, Bluetooth connection
-1. Via the SMS console through the [emnify Portal](https://portal.emnify.com/)
+1. Via the SMS console through the [emnify Portal](https://portal.emnify.com/connected-devices)
 1. Via the [emnify SMS API](https://cdn.emnify.net/api/doc/swagger.html#/Endpoint) or [Zapier Integration](https://zapier.com/apps/emnify/integrations/sms) (when automating the configuration)
 
 Newer Teltonika GPS versions automatically detect the emnify APN setting.
@@ -53,7 +53,7 @@ Refer to the [Teltonika FMB Device Family Parameter list](https://wiki.teltonika
 Configuring the APN for Ruptela GPS trackers can be done through:
 
 1. Ruptela Device Center over a USB, Bluetooth connection
-1. Via the SMS console through the [emnify Portal](https://portal.emnify.com/)
+1. Via the SMS console through the [emnify Portal](https://portal.emnify.com/connected-devices)
 1. Via the [emnify SMS API](https://cdn.emnify.net/api/doc/swagger.html#/Endpoint) or [Zapier Integration](https://zapier.com/apps/emnify/integrations/sms) (when automating the configuration)
 
 When the GPS tracker is turned on for the first time after the SIM is installed, it shows the status **Attached** in the emnify Portal.
@@ -78,7 +78,7 @@ setconnection em
 
 Configuring the APN for Concox GPS trackers can be done:
 
-1. Via the SMS console through the [emnify Portal](https://portal.emnify.com/)
+1. Via the SMS console through the [emnify Portal](https://portal.emnify.com/connected-devices)
 1. Via the [emnify SMS API](https://cdn.emnify.net/api/doc/swagger.html#/Endpoint) or [Zapier Integration](https://zapier.com/apps/emnify/integrations/sms) (when automating the configuration)
 
 When the GPS tracker is turned on for the first time after the SIM is installed, it shows the status **Attached** in the emnify Portal.
@@ -106,7 +106,7 @@ The default password is `666666`.
 
 Configuring the APN for Coban GPS trackers can be done:
 
-1. Via the SMS console through the [emnify Portal](https://portal.emnify.com/)
+1. Via the SMS console through the [emnify Portal](https://portal.emnify.com/connected-devices)
 1. Via the [emnify SMS API](https://cdn.emnify.net/api/doc/swagger.html#/Endpoint) or [Zapier Integration](https://zapier.com/apps/emnify/integrations/sms) (when automating the configuration)
 
 When the GPS tracker is turned on for the first time after the SIM is installed, it shows the status **Attached** in the emnify Portal.
@@ -139,7 +139,7 @@ The default password is `123456`.
 Configuring the APN for Meitrack GPS trackers can be done:
 
 1. Via the Meitrack manager
-1. Via the SMS console through the [emnify Portal](https://portal.emnify.com/)
+1. Via the SMS console through the [emnify Portal](https://portal.emnify.com/connected-devices)
 1. Via the [emnify SMS API](https://cdn.emnify.net/api/doc/swagger.html#/Endpoint) or [Zapier Integration](https://zapier.com/apps/emnify/integrations/sms) (when automating the configuration)
 
 When the GPS tracker is turned on for the first time after the SIM is installed, it shows the status **Attached** in the emnify Portal.
@@ -173,7 +173,7 @@ Both SMS and super password can be changed and would then need to be replaced in
 
 Configuring the APN for Elinz GPS trackers can be done:
 
-1. Via the SMS console through the [emnify Portal](https://portal.emnify.com/) 
+1. Via the SMS console through the [emnify Portal](https://portal.emnify.com/connected-devices) 
 1. Via the [emnify SMS API](https://cdn.emnify.net/api/doc/swagger.html#/Endpoint) or [Zapier Integration](https://zapier.com/apps/emnify/integrations/sms) (when automating the configuration)
 
 When the GPS tracker is turned on for the first time after the SIM is installed, it shows the status **Attached** in the emnify Portal.
@@ -199,7 +199,7 @@ The default password is `123456`.
 
 Configuring the APN for Reachfar GPS trackers can be done:
 
-1. Via the SMS console through the [emnify Portal](https://portal.emnify.com/)
+1. Via the SMS console through the [emnify Portal](https://portal.emnify.com/connected-devices)
 1. Via the [emnify SMS API](https://cdn.emnify.net/api/doc/swagger.html#/Endpoint) or [Zapier Integration](https://zapier.com/apps/emnify/integrations/sms) (when automating the configuration)
 
 When the GPS tracker is turned on for the first time after the SIM is installed, it shows the status **Attached** in the emnify Portal. 
@@ -238,7 +238,7 @@ apn,em# // Send this SMS from the phone
 
 Configuring the APN for Queclink GPS trackers can be done:
 
-1. Via the SMS console through the [emnify Portal](https://portal.emnify.com/)
+1. Via the SMS console through the [emnify Portal](https://portal.emnify.com/connected-devices)
 1. Via the [emnify SMS API](https://cdn.emnify.net/api/doc/swagger.html#/Endpoint) or Zapier Integration (when automating the configuration)
 
 When the GPS tracker is turned on for the first time after the SIM is installed, it shows the status **Attached** in the emnify Portal.
@@ -258,7 +258,7 @@ The default password is the device model (e.g., `gl200`).
 
 Configuring the APN for Bitrek GPS trackers can be done:
 
-1. Via the SMS console through the [emnify Portal](https://portal.emnify.com/)
+1. Via the SMS console through the [emnify Portal](https://portal.emnify.com/connected-devices)
 1. Via the [emnify SMS API](https://cdn.emnify.net/api/doc/swagger.html#/Endpoint) or [Zapier Integration](https://zapier.com/apps/emnify/integrations/sms) (when automating the configuration)
 
 When the GPS tracker is turned on for the first time after the SIM is installed, it shows the status **Attached** in the emnify Portal.

--- a/docs/quickstart/getting-started.md
+++ b/docs/quickstart/getting-started.md
@@ -15,7 +15,7 @@ You can order your free Evaluation SIM package on the emnify Portal with which y
 Currently, the 3 triple-cut SIM cards can be delivered to most destinations at no charge.
 For other destinations, we do charge a small shipping fee.
 
-Log into your [emnify account](https://portal.emnify.com/sign) and follow these steps:
+[Log into your emnify account](https://portal.emnify.com/sign) and follow these steps:
 
 1. On the dashboard, click on order on **Get your free SIMs**
 1. Select the **Free Evaluation Package with 3 Triple-cut SIMs**

--- a/docs/quickstart/getting-started.md
+++ b/docs/quickstart/getting-started.md
@@ -15,7 +15,7 @@ You can order your free Evaluation SIM package on the emnify Portal with which y
 Currently, the 3 triple-cut SIM cards can be delivered to most destinations at no charge.
 For other destinations, we do charge a small shipping fee.
 
-Log into your [emnify account](https://portal.emnify.com) and follow these steps:
+Log into your [emnify account](https://portal.emnify.com/sign) and follow these steps:
 
 1. On the dashboard, click on order on **Get your free SIMs**
 1. Select the **Free Evaluation Package with 3 Triple-cut SIMs**

--- a/docs/quickstart/registering-sims.md
+++ b/docs/quickstart/registering-sims.md
@@ -6,7 +6,7 @@ description: Using your emnify account to register your SIMs
 Once you get your emnify SIMs, you need to register them before you can start using them.
 If you order the free Evaluation SIM package, you will have to register each of the 3 SIMs separately.
 
-1. Log in to your [emnify account](https://portal.emnify.com).  
+1. Log in to your [emnify account](https://portal.emnify.com/sign).  
 1. From the **Get Started** menu, select [**Register SIM(s)**](https://portal.emnify.com/sim-registration)  
 <img
   src={require('./assets/portal-get-started-collapsible-register-sims-menu-item.png').default}

--- a/docs/rest-api/authentication.md
+++ b/docs/rest-api/authentication.md
@@ -9,7 +9,7 @@ We use JSON Web Tokens (JWTs) as the authentication token.
 
 There are two ways to retrieve this token:
 
-1. [**Authenticate with user credentials**](#authenticate-with-user-credentials): Use the username and password you provided while signing up for the [emnify Portal](https://portal.emnify.com/user-settings).
+1. [**Authenticate with user credentials**](#authenticate-with-user-credentials): Use the username and password you provided while signing up for the emnify Portal. This information is available in your [**User Settings**](https://portal.emnify.com/user-settings).
 1. [**Authenticate with an application token**](#authenticate-with-an-application-token): You can use the application token generated in your emnify account.
 
 ## Authenticate with user credentials
@@ -52,7 +52,7 @@ Once the `auth_token` expires, you can use the `refresh_token` to retrieve t
 
 ## Authenticate with an application token
 
-Since you shouldn't store your emnify user credentials on your application server, you can generate an `application_token` via the [emnify Portal](https://portal.emnify.com/integrations) or the API: `/api/v1/application_token`.
+Since you shouldn't store your emnify user credentials on your application server, you can generate an `application_token` via the [**Integrations** page of the emnify Portal](https://portal.emnify.com/integrations) or the API: `/api/v1/application_token`.
 The request body should have a description of the token normally used to indicate who is using the token and can have an `expiry_date` for the token.
 
 ```
@@ -88,7 +88,7 @@ The token can be revoked at any time.
 
 You can alternatively generate the `application_token` in the emnify Portal:
 
-1. Log in to the [emnify Portal](https://portal.emnify.com/sign)
+1. [Log in to the emnify Portal](https://portal.emnify.com/sign)
 1. Navigate to [**Integrations**](https://portal.emnify.com/integrations) → **Application Tokens** → **Add Token**.
 
 <!-- TODO: Recreate generate_app_token.png (generate application token) -->

--- a/docs/rest-api/authentication.md
+++ b/docs/rest-api/authentication.md
@@ -9,7 +9,7 @@ We use JSON Web Tokens (JWTs) as the authentication token.
 
 There are two ways to retrieve this token:
 
-1. [**Authenticate with user credentials**](#authenticate-with-user-credentials): Use the username and password you provided while signing up for the [emnify Portal](https://portal.emnify.com/).
+1. [**Authenticate with user credentials**](#authenticate-with-user-credentials): Use the username and password you provided while signing up for the [emnify Portal](https://portal.emnify.com/user-settings).
 1. [**Authenticate with an application token**](#authenticate-with-an-application-token): You can use the application token generated in your emnify account.
 
 ## Authenticate with user credentials
@@ -52,7 +52,7 @@ Once the `auth_token` expires, you can use the `refresh_token` to retrieve t
 
 ## Authenticate with an application token
 
-Since you shouldn't store your emnify user credentials on your application server, you can generate an `application_token` via the [emnify Portal](https://portal.emnify.com/) or the API: `/api/v1/application_token`.
+Since you shouldn't store your emnify user credentials on your application server, you can generate an `application_token` via the [emnify Portal](https://portal.emnify.com/integrations) or the API: `/api/v1/application_token`.
 The request body should have a description of the token normally used to indicate who is using the token and can have an `expiry_date` for the token.
 
 ```
@@ -88,8 +88,8 @@ The token can be revoked at any time.
 
 You can alternatively generate the `application_token` in the emnify Portal:
 
-1. Log in to the [emnify Portal](https://portal.emnify.com/login)
-1. Navigate to **Integrations** → **Application Tokens** → **Add Token**.
+1. Log in to the [emnify Portal](https://portal.emnify.com/sign)
+1. Navigate to [**Integrations**](https://portal.emnify.com/integrations) → **Application Tokens** → **Add Token**.
 
 <!-- TODO: Recreate generate_app_token.png (generate application token) -->
 

--- a/docs/sdks/python/getting-started.md
+++ b/docs/sdks/python/getting-started.md
@@ -31,7 +31,7 @@ pip install emnify-sdk
 ### Create an application token
 
 To use the Python SDK, you need to create an application token. 
-You can do this via the [emnify Portal](https://portal.emnify.com/) or [emnify REST API](https://www.emnify.com/developer-blog/how-to-use-an-application-token-for-api-authentication).
+You can do this via the [emnify Portal](https://portal.emnify.com/integrations) or [emnify REST API](https://www.emnify.com/developer-blog/how-to-use-an-application-token-for-api-authentication).
 
 Once created, you'll apply it to initiate the SDK.
 

--- a/docs/sdks/python/getting-started.md
+++ b/docs/sdks/python/getting-started.md
@@ -31,7 +31,7 @@ pip install emnify-sdk
 ### Create an application token
 
 To use the Python SDK, you need to create an application token. 
-You can do this via the [emnify Portal](https://portal.emnify.com/integrations) or [emnify REST API](https://www.emnify.com/developer-blog/how-to-use-an-application-token-for-api-authentication).
+You can do this via the [**Integrations** page of the emnify Portal](https://portal.emnify.com/integrations) or the [emnify REST API](https://www.emnify.com/developer-blog/how-to-use-an-application-token-for-api-authentication).
 
 Once created, you'll apply it to initiate the SDK.
 

--- a/docs/services/business-intelligence-and-analytics-reports.md
+++ b/docs/services/business-intelligence-and-analytics-reports.md
@@ -3,7 +3,7 @@ description: Analyze data usage, events, and device location over time
 ---
 # Business intelligence and analytics reports
 
-The [emnify Portal](https://portal.emnify.com/reports/default) provides detailed reports on all connectivity aspects of a device.
+The [emnify Portal provides detailed reports](https://portal.emnify.com/reports/default) on all connectivity aspects of a device.
 You can analyze the data consumption, events, location of the devices, and compare them to previous time periods.
 
 - Data traffic per day, week, month

--- a/docs/services/business-intelligence-and-analytics-reports.md
+++ b/docs/services/business-intelligence-and-analytics-reports.md
@@ -3,7 +3,7 @@ description: Analyze data usage, events, and device location over time
 ---
 # Business intelligence and analytics reports
 
-The [emnify Portal](https://portal.emnify.com) provides detailed reports on all connectivity aspects of a device.
+The [emnify Portal](https://portal.emnify.com/reports/default) provides detailed reports on all connectivity aspects of a device.
 You can analyze the data consumption, events, location of the devices, and compare them to previous time periods.
 
 - Data traffic per day, week, month

--- a/docs/services/data-streamer/usage.md
+++ b/docs/services/data-streamer/usage.md
@@ -16,8 +16,8 @@ Integrating the Data Streamer API becomes a faster and more secure approach when
 
 ## Data Streamer in the Portal
 
-To [manage your data streams](managing-data-streams), log in to your [emnify Portal](https://portal.emnify.com/sign/) account.
-Then, navigate to the [**Integrations**](https://portal.emnify.com/integrations) page by clicking the **Integrations** menu item in the sidebar.
+To [manage your data streams](managing-data-streams), [log in to your emnify Portal account](https://portal.emnify.com/sign/).
+Then, navigate to the [**Integrations** page](https://portal.emnify.com/integrations) by clicking the **Integrations** menu item in the sidebar.
 
 ### Viewing data streams
 

--- a/docs/services/data-streamer/usage.md
+++ b/docs/services/data-streamer/usage.md
@@ -16,8 +16,8 @@ Integrating the Data Streamer API becomes a faster and more secure approach when
 
 ## Data Streamer in the Portal
 
-To [manage your data streams](managing-data-streams), log in to your [emnify Portal](https://portal.emnify.com/) account.
-Then, navigate to the **Integrations** page by clicking the **Integrations** menu item in the sidebar.
+To [manage your data streams](managing-data-streams), log in to your [emnify Portal](https://portal.emnify.com/sign/) account.
+Then, navigate to the [**Integrations**](https://portal.emnify.com/integrations) page by clicking the **Integrations** menu item in the sidebar.
 
 ### Viewing data streams
 

--- a/docs/services/events/usage.md
+++ b/docs/services/events/usage.md
@@ -24,7 +24,7 @@ See the [Data Streamer documentation](../data-streamer/getting-started) to learn
 ### Managing event data streams in the Portal
 
 To manage your data streams, log in to your [emnify Portal](https://portal.emnify.com/) account. 
-Then, navigate to the [**Integrations**](https://portal.emnify.com/integrations) page by clicking the **Integrations** menu item in the sidebar.
+Then, navigate to the [**Integrations** page](https://portal.emnify.com/integrations) by clicking the **Integrations** menu item in the sidebar.
 
 If there are no data streams configured, the **Data Streams** panel displays all available connection types as tiles.
 
@@ -112,7 +112,7 @@ These event lists can be filtered, sorted, and paged according to query paramete
 
 ## emnify Portal
 
-There are several ways to view or trigger events within [the emnify Portal](https://portal.emnify.com/). 
+There are several ways to view or trigger events within the [emnify Portal](https://portal.emnify.com/). 
 
 ### Events in the Portal
 

--- a/docs/services/events/usage.md
+++ b/docs/services/events/usage.md
@@ -24,7 +24,7 @@ See the [Data Streamer documentation](../data-streamer/getting-started) to learn
 ### Managing event data streams in the Portal
 
 To manage your data streams, log in to your [emnify Portal](https://portal.emnify.com/) account. 
-Then, navigate to the **Integrations** page by clicking the **Integrations** menu item in the sidebar.
+Then, navigate to the [**Integrations**](https://portal.emnify.com/integrations) page by clicking the **Integrations** menu item in the sidebar.
 
 If there are no data streams configured, the **Data Streams** panel displays all available connection types as tiles.
 
@@ -123,12 +123,12 @@ Here's where you can find event information in the Portal:
   src={require('./assets/portal-dashboard-events.png').default}
   alt=""
 />
-- **Connected Devices** → **Details** → **Events**: List of triggered events for a particular device (also referred to as an "endpoint").
+- [**Connected Devices**](https://portal.emnify.com/connected-devices) → **Details** → **Events**: List of triggered events for a particular device (also referred to as an "endpoint").
 <img
   src={require('./assets/portal-connected-devices-details-events.png').default}
   alt=""
 />
-- **SIM Inventory** → **Details** → **Events**: List of triggered events for a particular SIM card.
+- [**SIM Inventory**](https://portal.emnify.com/sim-inventory) → **Details** → **Events**: List of triggered events for a particular SIM card.
 <img
   src={require('./assets/portal-sim-inventory-details-events.png').default}
   alt=""

--- a/docs/services/iot-cloud-communication-platform.md
+++ b/docs/services/iot-cloud-communication-platform.md
@@ -24,6 +24,6 @@ The data plane of emnify’s cloud communication platform is distributed across 
 emnify’s distributed data plane enables device data to breakout locally, keeping the customer data within the same region.
 Moreover, it also helps reduce network latency.
 You can either select a specific breakout region or the network automatically selects the breakout region closest to the device.
-This can be done on the [emnify Portal](https://portal.emnify.com/) → **Device Policies** → **New service policy** which is applicable to a group of devices.
+This can be done on the [emnify Portal](https://portal.emnify.com/) → [**Device Policies**](https://portal.emnify.com/device-policies) → **New service policy** which is applicable to a group of devices.
 
 ![Breakout regions](assets/portal-device-policies-breakout-regions.png)

--- a/docs/services/security.md
+++ b/docs/services/security.md
@@ -39,8 +39,7 @@ For example, Quectel uses the `AT+QIDNSCFG` command, SIMcom `AT+CDNSCFG` com
 This is useful to be able to use your own or private DNS servers to secure and have better control over the solution.
 
 Customers can also configure to use their own DNS, no matter if it is a public or a private one.
-The DNS settings can be changed in the Portal → Device Policies → Service Policies → More Options → DNS.
-[emnify Portal](https://portal.emnify.com/) → **Device Policies** [emnify Portal](https://portal.emnify.com/) → **Device Policies** → **New service policy** → **More options**
+The DNS settings can be changed in the [emnify Portal](https://portal.emnify.com/) → [**Device Policies**](https://portal.emnify.com/device-policies) → **New service policy** → **More options**
 
 <img
   src={require('./assets/portal-configure-custom-dns.png').default}

--- a/docs/services/sms.md
+++ b/docs/services/sms.md
@@ -25,7 +25,7 @@ You can send and receive SMSs of your devices through 3 different interfaces Por
 
 ## emnify Portal
 
-In the [Portal](https://portal.emnify.com/) → [**Connected Devices**](https://portal.emnify.com/connected-devices) you can access the SMS console and directly send SMS to the devices. 
+In the [emnify Portal](https://portal.emnify.com/) → [**Connected Devices**](https://portal.emnify.com/connected-devices) you can access the SMS console and directly send SMS to the devices. 
 The sender can be configured as well as the console will show if the SMS is delivered or not.
 You will see all SMSs that the device receives sends out.
 
@@ -125,7 +125,7 @@ The SMS will then be delivered over the webhook.
 Instead of implementing the APIs in your application, emnify and Zapier provide a no-code alternative to automate SMS workflows.
 Zapier has a concept of triggers and actions – when a trigger happens multiple actions can be based on it – taking content from previous steps.
 Sending SMS to your devices is available as an action in Zapier.
-In the **No-Code-Workflows** list of [Portal Integrations](https://portal.emnify.com/integrations), select the following:
+In the **No-Code-Workflows** list on the [**Integrations** page of the emnify Portal](https://portal.emnify.com/integrations), select the following:
 
 <img
   src={require('./assets/portal-integrations-sms-webhooks-zapier.png').default}

--- a/docs/services/sms.md
+++ b/docs/services/sms.md
@@ -25,7 +25,7 @@ You can send and receive SMSs of your devices through 3 different interfaces Por
 
 ## emnify Portal
 
-In the [Portal](https://portal.emnify.com/) → **Connected Devices** you can access the SMS console and directly send SMS to the devices. 
+In the [Portal](https://portal.emnify.com/) → [**Connected Devices**](https://portal.emnify.com/connected-devices) you can access the SMS console and directly send SMS to the devices. 
 The sender can be configured as well as the console will show if the SMS is delivered or not.
 You will see all SMSs that the device receives sends out.
 

--- a/docs/sso/google-cloud-platform.md
+++ b/docs/sso/google-cloud-platform.md
@@ -57,7 +57,7 @@ You can access your client ID and secret at any time in your Google Cloud Platfo
 
 ## Configure the emnify Portal
 
-1. Log in to the [emnify Portal](https://portal.emnify.com/sign/).
+1. [Log in to the emnify Portal](https://portal.emnify.com/sign/).
 1. Go to **Organization Settings** (building icon) in the top-level navigation and click [**Single Sign-On**](https://portal.emnify.com/organisation-settings/federation).
 1. If you need SSO enabled for your account, [contact support](https://support.emnify.com/). 
 Otherwise, click **Add** under the Google SSO provider.

--- a/docs/sso/google-cloud-platform.md
+++ b/docs/sso/google-cloud-platform.md
@@ -57,8 +57,8 @@ You can access your client ID and secret at any time in your Google Cloud Platfo
 
 ## Configure the emnify Portal
 
-1. Log in to the [emnify Portal](https://portal.emnify.com/).
-1. Go to **Organization Settings** (building icon) in the top-level navigation and click **Single Sign-On**.
+1. Log in to the [emnify Portal](https://portal.emnify.com/sign/).
+1. Go to **Organization Settings** (building icon) in the top-level navigation and click [**Single Sign-On**](https://portal.emnify.com/organisation-settings/federation).
 1. If you need SSO enabled for your account, [contact support](https://support.emnify.com/). 
 Otherwise, click **Add** under the Google SSO provider.
 1. Fill in the **Client ID** and **Client Secret** you copied earlier, then click **Create and Activate**.

--- a/docs/sso/microsoft-active-directory.md
+++ b/docs/sso/microsoft-active-directory.md
@@ -108,7 +108,7 @@ Navigate to **Overview** in the sidebar and copy the **Application (client) I
 
 ## Configure the emnify Portal
 
-Log in to your [emnify account](https://portal.emnify.com/sign/), go to Organization Settings (building icon) in the top-level navigation, and click [**Single Sign-On**](https://portal.emnify.com/organisation-settings/federation).
+[Log in to your emnify account](https://portal.emnify.com/sign/), go to Organization Settings (building icon) in the top-level navigation, and click [**Single Sign-On**](https://portal.emnify.com/organisation-settings/federation).
 
 <img
   src={require('./assets/portal-organization-settings-sso.png').default}

--- a/docs/sso/microsoft-active-directory.md
+++ b/docs/sso/microsoft-active-directory.md
@@ -108,7 +108,7 @@ Navigate to **Overview** in the sidebar and copy the **Application (client) I
 
 ## Configure the emnify Portal
 
-Log in to your emnify account, go to Organization Settings (building icon) in the top-level navigation, and click **Single Sign-On**.
+Log in to your [emnify account](https://portal.emnify.com/sign/), go to Organization Settings (building icon) in the top-level navigation, and click [**Single Sign-On**](https://portal.emnify.com/organisation-settings/federation).
 
 <img
   src={require('./assets/portal-organization-settings-sso.png').default}


### PR DESCRIPTION
### Description

We received feedback from one of the Application & Integrations PMs (Bas) about how a majority of the existing links to the emnify Portal were only navigating to the homepage. In some cases, it's more useful to link to the specific page where the reader should be navigating to perform the described action.

This PR 🔖 
- Deep links within the Portal wherever possible
- Links as close to the actual spot as the UI anchors allow us to
- Ensures that the linked text is consistent for identical paths and as descriptive as possible

### Additional Context

Internal ticket 🎟️ [SDOCS-232](https://emnify.atlassian.net/browse/SDOCS-232)