### PR TITLE
APN configuration should be a subsection of getting device online

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -28,12 +28,24 @@ const sidebars = {
           },
           items: [
             "quickstart/devices/creating-a-device",
-            "quickstart/devices/getting-the-first-device-online",
-            "quickstart/devices/android",
-            "quickstart/devices/ios-devices",
-            "quickstart/devices/cellular-modules",
-            "quickstart/devices/gps-trackers",
-            "quickstart/devices/industrial-routers",
+            {
+              type: "category",
+              label: "Getting the device online",
+              link: {
+                type: "generated-index",
+                title: "Getting the first device online",
+                slug: "quickstart/devices/apn-configuration",
+                description:
+                  "Configuring SIM-equipped devices with an Access Point Name (APN)",
+              },
+              items: [
+                "quickstart/devices/android",
+                "quickstart/devices/ios-devices",
+                "quickstart/devices/cellular-modules",
+                "quickstart/devices/gps-trackers",
+                "quickstart/devices/industrial-routers",
+              ],
+            },
           ],
         },
         "quickstart/troubleshooting",


### PR DESCRIPTION
### Description

The title of the PR is the same as the internal story's title.

### Additional Context

It doesn't really make sense to alter the folder structure to mimic the sidebar structure.
The initial changes committed fulfill the story's requirements.
However, since their are some issues with this part of the documentation, we should consider whether some minor out-of-scope fixes should be done here or in a separate PR:

- **iOS devices** vs **Android** (missing "devices")
- Also, the subtitles taken from the description in the generated index do not match:

<img width="858" alt="subtitle-mismatch" src="https://user-images.githubusercontent.com/49970529/217215806-8e0beb9c-fd6b-4fd9-84b4-60d2833780a6.png">



Internal 🎫 [SDOCS-222](mnify.atlassian.net/browse/SDOCS-222)

[SDOCS-222]: https://emnify.atlassian.net/browse/SDOCS-222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ