### PR TITLE
Create Integration Guides index page

### DIFF
--- a/docs/integration-guides/index.md
+++ b/docs/integration-guides/index.md
@@ -1,0 +1,39 @@
+# Integration guides
+
+emnify services can be easily integrated with your existing infrastructure.
+Here are some step-by-step integration guides to help you along the process.
+
+## Amazon Web Services
+
+- [emnify and AWS IoT Core integration](https://www.emnify.com/integration-guides/emnify-and-aws-iot-core-integration)
+- [emnify Data Streamer integration into AWS Kinesis](https://www.emnify.com/en/developer-hub/emnify-datastreamer-integration-into-aws-kinesis)
+- [emnify Data Streamer integration into AWS S3](https://www.emnify.com/en/developer-hub/emnify-datastreamer-integration-into-aws-s3)
+- [emnify Cloud Connect integration with AWS Transit Gateway](https://www.emnify.com/en/developer-hub/emnify-cloud-connect-into-aws-transit-gateway)
+
+## Microsoft Azure
+
+- [emnify Data Streamer integration into Azure Event Hub](https://www.emnify.com/en/developer-hub/emnify-datastreamer-integration-into-azure-event-hub)
+- [emnify and Azure IoT Hub integration](https://www.emnify.com/en/developer-hub/emnify-and-azure-iot-hub-integration)
+- [emnify Data Streamer integration for Azure Time Series Classic](https://www.emnify.com/en/developer-hub/emnify-datastreamer-integration-for-azure-time-series-classic)
+- [emnify Cloud Connect integration into Azure Virtual Network Gateway](https://www.emnify.com/en/developer-hub/emnify-cloud-connect-azure-integration)
+- [emnify Data Streamer integration for Power BI](https://www.emnify.com/en/developer-hub/emnify-datastreamer-integration-for-power-bi)
+
+## Google Cloud
+
+- [emnify DataStreamer integration for Google BigQuery](https://www.emnify.com/en/developer-hub/datastreamer-integration-google-bigquery)
+- [emnify and Google Cloud IoT Core integration](https://www.emnify.com/en/developer-hub/emnify-and-google-cloud-iot-core-integration)
+- [emnify Cloud Connect Integration to Google Cloud Platform](https://www.emnify.com/en/developer-hub/emnify-cloudconnect-integration-to-google-cloud-platform)
+- [emnify Data Streamer integration for Google Cloud Pub/Sub](https://www.emnify.com/en/developer-hub/datastreamer-integration-into-google-cloud-pubsub)
+
+
+## Webhooks
+
+- [Automate Business Processes with Multi Cloud Data Streamer and Integromat](https://www.emnify.com/en/developer-hub/emnify-mcds-integromat-integration)
+- [How to receive email notifications using Automate.io](https://www.emnify.com/en/developer-hub/how-to-receice-email-notifications-using-automate.io)
+
+## Other integrations
+
+- [emnify Data Streamer integration for Datadog](https://www.emnify.com/en/developer-hub/emnify-datastreamer-integration-for-datadog)
+- [How to setup an IPsec using emnify Cloud Connect](https://www.emnify.com/en/developer-hub/how-to-setup-an-ipsec-using-emnify-cloudconnect)
+- [emnify Data Streamer integration for Keen.io](https://www.emnify.com/integration-guides/emnify-datastreamer-integration-for-keen-io)
+- [USSD integration guide](https://www.emnify.com/en/developer-hub/ussd-integration-guide)

--- a/docs/integration-guides/index.md
+++ b/docs/integration-guides/index.md
@@ -1,6 +1,6 @@
 # Integration guides
 
-emnify services can be easily integrated with your existing infrastructure.
+emnify services can be integrated with your existing infrastructure.
 Here are some step-by-step integration guides to help you along the process.
 
 ## Amazon Web Services

--- a/sidebars.js
+++ b/sidebars.js
@@ -206,6 +206,11 @@ const sidebars = {
         },
       ],
     },
+    {
+      type: "doc",
+      label: "Integration guides",
+      id: "integration-guides/index",
+    },
     "glossary",
   ],
   restSidebar: [

--- a/sidebars.js
+++ b/sidebars.js
@@ -206,11 +206,7 @@ const sidebars = {
         },
       ],
     },
-    {
-      type: "doc",
-      label: "Integration guides",
-      id: "integration-guides/index",
-    },
+    "integration-guides/index",
     "glossary",
   ],
   restSidebar: [


### PR DESCRIPTION
### Description

Our documentation is going to replace the “Integration guides” link under “Resources” so we want to make sure that those are accessible for readers.

As discussed in the Docs Sync, the current UI for the Integration guides isn’t very user-friendly, so we think it’d be better to:

Create an index page listing all the guides

Potentially sort those links by category (if its clear)

Then, as we migrate those integration guides, we can replace the link to [emnify.com](http://emnify.com/) with the link to the page in our docs platform.

### Additional Context

1. Changed all title links to match the actual titles of the external document
It can be confusing to visitors when the document's title is different from the title they clicked.
2. Changed the link titles to sentence case
3. Replaced random ordering in each section to having titles sorted by 3rd-party product name

Internal 🎫  [SDOCS-248](https://emnify.atlassian.net/browse/SDOCS-248)

[SDOCS-248]: https://emnify.atlassian.net/browse/SDOCS-248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ