### PR TITLE
Show "Last updated" timestamps on all documentation pages

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -31,6 +31,7 @@ const config = {
           sidebarPath: require.resolve("./sidebars.js"),
           routeBasePath: "/",
           editUrl: "https://github.com/emnify/product-docs/blob/main/",
+          showLastUpdateTime: true,
         },
         theme: {
           customCss: require.resolve("./src/css/custom.css"),


### PR DESCRIPTION
### Description

Set `showLastUpdateTime` to `true` in our Docusaurus config 🦖 

That way, our readers can know how up-to-date the content is and it could also help us as maintainers. 

### ✨ Visual preview

<img width="451" alt="Screenshot 2023-02-09 at 15 19 08" src="https://user-images.githubusercontent.com/26869552/217839896-06aca51f-83a9-4400-92c0-6fbf6106c927.png">

<details>
<summary>Entire page</summary>
<img width="1285" alt="Screenshot 2023-02-09 at 15 18 55" src="https://user-images.githubusercontent.com/26869552/217839811-efbea149-4d52-4704-9ace-3cd7c450bb57.png">
</details>

### Additional context

We also have the option to set `showLastUpdateAuthor` but I didn't think it was as relevant to this project because there will be many cases where stakeholders will send the content or feedback and then our docs team updates it for them.