### PR TITLE
Create an index page for the external how-tos

### DIFF
--- a/docs/how-tos/index.md
+++ b/docs/how-tos/index.md
@@ -1,0 +1,14 @@
+# How-tos
+
+- [4 ways to send SMS to your devices manually and automatically](https://www.emnify.com/developer-blog/4-ways-to-send-sms)
+- [5 ways to detect connection errors and how to resolve them](https://www.emnify.com/developer-blog/5-ways-to-detect-and-solve-connectivity-issues)
+- [AT commands for GSM](https://www.emnify.com/developer-blog/at-commands-for-cellular-modules)
+- [Create an IoT gateway with emnify, Raspberry Pi, and Sixfab](https://www.emnify.com/developer-blog/getting-started-on-your-iot-journey-with-emnify-and-raspberry-pi)
+- [How to access any IoT device or web server behind a Teltonika Networks router](https://www.emnify.com/developer-blog/how-to-access-iot-device-or-web-server-behind-a-teltonika-router)
+- [How to automate workflows with Zapier and emnify in 5 minutes](https://www.emnify.com/developer-blog/emnify-zapier-nocode)
+- [How to fit a Raspberry Pi with mobile connectivity](https://www.emnify.com/developer-blog/how-to-fit-a-raspberry-pi-with-mobile-connectivity)
+- [How to send and receive SMS via the API](https://www.emnify.com/developer-blog/how-to-send-and-receive-sms-via-the-api)
+- [How to stop SIM theft from increasing your fleet tracking costs](https://www.emnify.com/blog/how-to-stop-sim-theft-from-increasing-fleet-costs)
+- [How to use an Application Token for API authentication](https://www.emnify.com/developer-blog/how-to-use-an-application-token-for-api-authentication)
+- [How to use Rest-API via Postman](https://www.emnify.com/developer-blog/postman-emnify-api)
+- [Ultimate guide to update IoT firmware with emnify and serverless on AWS](https://www.emnify.com/developer-blog/how-to-automate-iot-management-with-aws)

--- a/sidebars.js
+++ b/sidebars.js
@@ -206,6 +206,7 @@ const sidebars = {
         },
       ],
     },
+    "how-tos/index",
     "glossary",
   ],
   restSidebar: [


### PR DESCRIPTION
### Description

The initial goal is to migrate all Developer Blog posts that follow the "how-to" genre of instructional material. This means the content, not the title, determines a post's inclusion in this index.

There might be some slight overlap with some of the integration topics. However, it is assumed that any 3rd-party integration material that might be included is not the primary focus of the post. Had this not been the case, the author would have created the post as a standalone integration guide.

### Additional Context

Migrating content is beyond the scope of this issue/PR.

Any content updates to a how-to will involve a separate story/PR for migrating and editing the respective post.