### PR TITLE
Mention the initial pre-paid credit in the Quickstart guide

### DIFF
--- a/docs/quickstart/getting-started.md
+++ b/docs/quickstart/getting-started.md
@@ -40,7 +40,7 @@ To begin developing your IoT solutions with emnify, you'll need an emnify accoun
 ![Claim your free evaluation package with 3 triple-cut SIMs to kickstart your well-managed IoT journey. Includes: Free 3 triple-cut SIMs, form factor (Nano, Micro, Mini), our full coverage, and global fast shipping.](assets/portal-order-evaluation-pack.png)
 
 You can order your free Evaluation SIM package on the emnify Portal.
-The package also includes an initial 10 EUR or USD of pre-paid credit to help you test emnify's services.
+This package includes a prepaid credit of 10 EUR/USD for testing emnify's services.
 
 :::note
 You have 60 days to use this pre-paid credit.

--- a/docs/quickstart/getting-started.md
+++ b/docs/quickstart/getting-started.md
@@ -43,12 +43,12 @@ You can order your free Evaluation SIM package on the emnify Portal.
 This package includes a prepaid credit of 10 EUR/USD for testing emnify's services.
 
 :::note
-You have 60 days to use this pre-paid credit.
+You have 60 days to use this prepaid credit.
 :::
 
 Currently, the 3 triple-cut SIM cards can be delivered to most destinations worldwide with express shipment.
 
-To get your free Evaluation SIM package, [log into your emnify account](https://portal.emnify.com/sign) and follow these steps:
+To get your free Evaluation SIM package, [log in to your emnify account](https://portal.emnify.com/sign) and follow these steps:
 
 1. On the dashboard, click on order on **Get your free SIMs**
 1. Select the **Free Evaluation Package with 3 Triple-cut SIMs**

--- a/docs/quickstart/getting-started.md
+++ b/docs/quickstart/getting-started.md
@@ -39,11 +39,16 @@ To begin developing your IoT solutions with emnify, you'll need an emnify accoun
 
 ![Claim your free evaluation package with 3 triple-cut SIMs to kickstart your well-managed IoT journey. Includes: Free 3 triple-cut SIMs, form factor (Nano, Micro, Mini), our full coverage, and global fast shipping.](assets/portal-order-evaluation-pack.png)
 
-You can order your free Evaluation SIM package on the emnify Portal with which you can test all emnify services.
+You can order your free Evaluation SIM package on the emnify Portal.
+The package also includes an initial 10 EUR or USD of pre-paid credit to help you test emnify's services.
+
+:::note
+You have 60 days to use this pre-paid credit.
+:::
+
 Currently, the 3 triple-cut SIM cards can be delivered to most destinations worldwide with express shipment.
 
-
-[Log into your emnify account](https://portal.emnify.com/sign) and follow these steps:
+To get your free Evaluation SIM package, [log into your emnify account](https://portal.emnify.com/sign) and follow these steps:
 
 1. On the dashboard, click on order on **Get your free SIMs**
 1. Select the **Free Evaluation Package with 3 Triple-cut SIMs**


### PR DESCRIPTION
### Description

Growth squad has a ticket about communicating the initial 10 $/€ of pre-paid credit 🤑  This number is consistent for all new accounts, so it makes sense to add it to the documentation. I used the emnify Terms of Service to determine specifics about that amount. 

### Additional Context

Internal ticket 🎟️  [PGR-203](https://emnify.atlassian.net/browse/PGR-203)


[PGR-203]: https://emnify.atlassian.net/browse/PGR-203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ