### PR TITLE
Adjust links to Integration page of Portal to use header anchors

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -173,6 +173,10 @@ A technology that allows changes to the SIM memory [over–the–air](#ota---ove
 ## OpenVPN  
 An open-source software application that implements [virtual private network (VPN)](#vpn) techniques for creating secure point–to–point or site–to–site connections in routed or bridged configurations and remote access facilities.
 
+:::tip
+[emnify hosts an OpenVPN service](/services/openvpn) that allows you to establish a private network between a device and any remote client location.
+:::
+
 ## P2P SMS - Peer–to–Peer SMS  
 SMS exchanged between devices.
 

--- a/docs/rest-api/authentication.md
+++ b/docs/rest-api/authentication.md
@@ -53,7 +53,7 @@ Once the `auth_token` expires, you can use the `refresh_token` to retrieve t
 
 ## Authenticate with an application token
 
-Since you shouldn't store your emnify user credentials on your application server, you can generate an `application_token` via the [**Integrations** page of the emnify Portal](https://portal.emnify.com/integrations) or the API: `/api/v1/application_token`.
+Since you shouldn't store your emnify user credentials on your application server, you can generate an `application_token` via the [emnify Portal](https://portal.emnify.com/integrations#application-tokens) or the API: `/api/v1/application_token`.
 The request body should have a description of the token normally used to indicate who is using the token and can have an `expiry_date` for the token.
 
 ```
@@ -90,7 +90,7 @@ The token can be revoked at any time.
 You can alternatively generate the `application_token` in the emnify Portal:
 
 1. [Log in to the emnify Portal](https://portal.emnify.com/sign)
-1. Navigate to [**Integrations**](https://portal.emnify.com/integrations) → **Application Tokens** → **Add Token**.
+1. Navigate to [**Integrations**](https://portal.emnify.com/integrations) → [**Application Tokens**](https://portal.emnify.com/integrations#application-tokens) → **Add Token**.
 
 <!-- TODO: Recreate generate_app_token.png (generate application token) -->
 

--- a/docs/sdks/python/getting-started.md
+++ b/docs/sdks/python/getting-started.md
@@ -33,7 +33,7 @@ pip install emnify-sdk
 ### Create an application token
 
 To use the Python SDK, you need to create an application token. 
-You can do this via the [**Integrations** page of the emnify Portal](https://portal.emnify.com/integrations) or the [emnify REST API](https://www.emnify.com/developer-blog/how-to-use-an-application-token-for-api-authentication).
+You can do this via the [**Integrations** page of the emnify Portal](https://portal.emnify.com/integrations#application-tokens) or the [emnify REST API](/rest-api/authentication#authenticate-with-an-application-token).
 
 Once created, you'll apply it to initiate the SDK.
 

--- a/docs/services/data-streamer/usage.md
+++ b/docs/services/data-streamer/usage.md
@@ -17,11 +17,11 @@ Integrating the Data Streamer API becomes a faster and more secure approach when
 ## Data Streamer in the Portal
 
 To [manage your data streams](managing-data-streams), [log in to your emnify Portal account](https://portal.emnify.com/sign/).
-Then, navigate to the [**Integrations** page](https://portal.emnify.com/integrations) by clicking the **Integrations** menu item in the sidebar.
+Then, navigate to the [**Data Streams**](https://portal.emnify.com/integrations#data-streams) section of the [**Integrations** page](https://portal.emnify.com/integrations).
 
 ### Viewing data streams
 
-If there are no data streams configured, the **Data Streams** panel displays all available [connection types](connection-types) as tiles.
+If there are no data streams configured, the [**Data Streams**](https://portal.emnify.com/integrations#data-streams) panel displays all available [connection types](connection-types) as tiles.
 
 <img
   src={require('./assets/portal-integrations-data-streams-panel.png').default}
@@ -30,6 +30,7 @@ If there are no data streams configured, the **Data Streams** panel displays all
 
 If you already have a data stream configured, the panel displays all existing streams, ordered by creation date (newest on the top).
 This list view can be used to gain an overview of the current states of different data streams.
+
 Data streams are marked as **Running** are properly operating.
 Failed streams exhibit an **Error** status.
 Paused streams are marked as **Paused**.
@@ -56,7 +57,7 @@ When no configured data streams are available, click **Add** on the preferred co
   alt=""
 />
 
-Otherwise, click **Add New Stream** at the top of the existing **Data Streams** list.
+Otherwise, click **Add New Stream** at the top of the existing [**Data Streams**](https://portal.emnify.com/integrations#data-streams) list.
 This shows the connection type tiles. You can choose your preferred connection type and click **Add**.
 
 <img

--- a/docs/services/events/usage.md
+++ b/docs/services/events/usage.md
@@ -23,8 +23,8 @@ See the [Data Streamer documentation](/services/data-streamer/getting-started) t
 
 ### Managing event data streams in the Portal
 
-To manage your data streams, log in to your [emnify Portal](https://portal.emnify.com/) account. 
-Then, navigate to the [**Integrations** page](https://portal.emnify.com/integrations) by clicking the **Integrations** menu item in the sidebar.
+To manage your data streams, log in to your [emnify Portal](https://portal.emnify.com/) account.
+Then, navigate to the [**Data Streams**](https://portal.emnify.com/integrations#data-streams) section of the [**Integrations** page](https://portal.emnify.com/integrations).
 
 If there are no data streams configured, the **Data Streams** panel displays all available connection types as tiles.
 

--- a/docs/services/no-code-workflow-automation.md
+++ b/docs/services/no-code-workflow-automation.md
@@ -25,3 +25,7 @@ Using the Zapier webhook, you can also use triggers from:
 
 - SMS delivered notification
 - Mobile originated (MO) SMS
+
+:::tip
+Browse the available workflows in the emnify Portal by navigating to the [**No-Code Workflows**](https://portal.emnify.com/integrations#no-code-workflows) section of the [**Integrations**](https://portal.emnify.com/integrations) page.
+:::

--- a/docs/services/openvpn.md
+++ b/docs/services/openvpn.md
@@ -3,31 +3,38 @@ description: Overview and setup
 ---
 # OpenVPN
 
-emnify’s communication platform hosts an OpenVPN service that allows to establish a private network between the device and any remote client location. 
-The remote client can either be on the application server itself, or on any machine that wants to remotely access the device (such as operational staff).
+emnify's communication platform hosts an OpenVPN service that allows you to establish a private network between a device and any remote client location. 
+The remote client can be on the application server or any machine that wants to access the device remotely (such as operational staff).
 
-## OpenVPN overview
+## IoT device requirements
 
-To use the OpenVPN service the IoT device does not need any private APN, OpenVPN software or dynamic DNS resolution.
-Through the emnify SIM, every device will get a static private IP address which can be used to identify and address the device.
+Your IoT device doesn't need a private APN, OpenVPN software, or dynamic DNS resolution to use the OpenVPN service.
+Through the emnify SIM, each device will have a [static](/glossary#static-ip) [private IP address](/glossary#private-ip) that you can use to identify and address the device.
 
 <!--This image is missing: OpenVPN.png -->
 <!-- image caption: OpenVPN System Overview -->
 
-At the same time the IoT device can send data through the private tunnel to the IP address of the remote machine.
+At the same time, the IoT device can send data through the private tunnel to the IP address of the remote machine.
 
-## OpenVPN setup
+## Setting up OpenVPN using the emnify Portal
 
-In order to set up OpenVPN on your machine the following high-level steps are required.
+The following steps are required to set up OpenVPN on your machine:
 
 1. In the [emnify Portal](https://portal.emnify.com/) → [**Device Policies**](https://portal.emnify.com/device-policies): Set the **Service Policy** to a VPN breakout region, e.g., `eu-west-1 (VPN)`
-1. In the [emnify Portal](https://portal.emnify.com/) → [**Integrations**](https://portal.emnify.com/integrations) → **OpenVPN**: download the VPN configuration file for your region and operating system
-1. Create a `credentials.txt` with your username / password or organisation ID / application token (recommended).
-1. Load the VPN configuration file and `credentials.txt` with your OpenVPN client
-    
+1. In the [emnify Portal](https://portal.emnify.com/) → [**Integrations**](https://portal.emnify.com/integrations) → [**Secure Connection**](https://portal.emnify.com/integrations#secure-connection) → **OpenVPN** → Click **Show Instructions** 
+1. Select your operating system and install the OpenVPN software.
+1. Download and store the VPN configuration file for your region.
+1. Create the `credentials.txt` file as instructed, using either your [user credentials](https://portal.emnify.com/user-settings) or your [organization ID](https://portal.emnify.com/organisation-settings/details) and [application token](https://portal.emnify.com/integrations#application-tokens) (recommended)
+1. Follow the remaining steps in the Portal to start the OpenVPN application or service on your operating system.
 
-For detailed instructions please refer to our knowledge base articles:
+:::caution
+You can't use accounts with multi-factor authentication (MFA) enabled to authenticate the OpenVPN tunnel.
+:::
 
-1. [OpenVPN Integration MacOS](https://support.emnify.com/hc/en-us/articles/360019625379-OpenVPN-Integration-Guide-for-MacOS)
-1. [OpenVPN Integration Windows](https://support.emnify.com/hc/en-us/articles/115001723273-OpenVPN-Integration-Guide-for-Windows) 
-1. [OpenVPN Integration Linux](https://support.emnify.com/hc/en-us/articles/115001724434-OpenVPN-Integration-Guide-for-Linux)
+:::tip
+For more detailed instructions based on your operating system, please refer to our knowledge base articles:
+
+- [MacOS](https://support.emnify.com/hc/en-us/articles/360019625379-OpenVPN-Integration-Guide-for-MacOS)
+- [Windows](https://support.emnify.com/hc/en-us/articles/115001723273-OpenVPN-Integration-Guide-for-Windows) 
+- [Linux](https://support.emnify.com/hc/en-us/articles/115001724434-OpenVPN-Integration-Guide-for-Linux)
+:::

--- a/docs/services/sms.md
+++ b/docs/services/sms.md
@@ -130,7 +130,7 @@ The SMS will then be delivered over the webhook.
 Instead of implementing the APIs in your application, emnify and Zapier provide a no-code alternative to automate SMS workflows.
 Zapier has a concept of triggers and actions – when a trigger happens multiple actions can be based on it – taking content from previous steps.
 Sending SMS to your devices is available as an action in Zapier.
-In the **No-Code-Workflows** list on the [**Integrations** page of the emnify Portal](https://portal.emnify.com/integrations), select the following:
+In the [**No-Code-Workflows**](https://portal.emnify.com/integrations#no-code-workflows) list on the [**Integrations** page of the emnify Portal](https://portal.emnify.com/integrations), select the following:
 
 ![Portal screenshot from the Integrations page. The featured integration reads, "Enable devices and send SMSes via emnify from newly caught webhooks. emnify + Webhooks by Zapier". Next to the text, there's a "Use this Zap" button.](assets/portal-integrations-sms-webhooks-zapier.png)
 


### PR DESCRIPTION
### Description

Growth squad has a task open to ensure that we're able to deeplink to all headers on the Integrations page of the Portal. Because we know what the anchor text will be, these links can already be added to the documentation 🎉 

⚠️ **Important note:** Not every deeplink anchor used in this PR has been implemented in the Portal yet. This will be done in [PGR-217](https://emnify.atlassian.net/browse/PGR-217). That said, the links will still land reads on the Integrations page and the anchors will work once that is deployed to Portal prod.

### Bonus 🍬 

I also cleaned up the OpenVPN page, including:
- Quick grammar sweep  
- New headers to better reflect content
- Updated the setup instructions to better reflect Portal flow
- Adding a reference to this page in the OpenVPN Glossary entry 

🧼 🧼 🧼 

### Additional Context

Internal ticket 🎫 [PGR-233](https://emnify.atlassian.net/browse/PGR-233)


[PGR-217]: https://emnify.atlassian.net/browse/PGR-217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PGR-233]: https://emnify.atlassian.net/browse/PGR-233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ