### PR TITLE
Remove acronym descriptions from Glossary headers

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -7,7 +7,7 @@ The device can send and receive data and SMS.
 ## APN
 _Access Point Name_
 
-A gateway between a [GSM](#gsm---global-system-for-mobile-communications), GPRS, 3G, or 4G mobile network and another computer network, usually the public Internet.
+A gateway between a [GSM](#gsm), GPRS, 3G, or 4G mobile network and another computer network, usually the public Internet.
 The APN needs to be configured on the device. For emnify, it is `em` or `emnify`.
 
 ## Application token  
@@ -28,7 +28,7 @@ Gives information about the registration status and access technology of the ser
 ## AuC
 _Authentication Center_
 
-A part of [GSM](#gsm---global-system-for-mobile-communications) infrastructure, validates any SIM card attempting network connection when a phone has a live network signal.
+A part of [GSM](#gsm) infrastructure, validates any SIM card attempting network connection when a phone has a live network signal.
 
 ## BIC
 _Batch Identification Code_
@@ -84,7 +84,7 @@ Instead of using a periodicity of 2.56ms (DRX) it can be increased up to 40mins,
 ## EID
 _eUICC Identifier_
 
-The eUICC Identifier (EID) provides a unique global serial number for an [eUICC](#euicc---embedded-universal-integrated-circuit-card).
+The eUICC Identifier (EID) provides a unique global serial number for an [eUICC](#euicc).
 It has a fixed length of 32 digits, as indicated in the following diagram:
 
 ![A 32-digit EID number: "89049011803455664400046832584675". The first 18 digits are the EUM Identification Number (EIN). Within those 18 digits, the first two digits are the Major Industry Identifier (Telecom in this example). The next three digits are the Country Code (GER in this example). The next three digits are the eUICC Manufacturer. The final 10 digits of the EIN contain information about the chip, OS, and its version. After the EIN, the following 11 digits are the EUM Specific Identification Number (ESIN). This value is also the eUICC Individual Identification Number. The final two digits of the EID are the Check Digits.](assets/infographic-eid-digits.png)
@@ -105,15 +105,15 @@ The current state of the [endpoint](#endpoint): **Enabled** or **Disabled**.
 ## eSIM
 _Embedded SIM_
 
-Because of the "e" (for *embedded*) in its name, *eSIM* is sometimes incorrectly used for referring to the MFF2 physical form factor of an [eUICC](#euicc---embedded-universal-integrated-circuit-card) chip that is designed to be permanently surface-mounted inside a device.
-Within the IoT industry, *eSIM* refers to the entire solution that is comprised of an eUICC-equipped [SIM](#sim---subscriber-identification-module) along with the software platform for [OTA provisioning](#ota-provisioning).
+Because of the "e" (for *embedded*) in its name, *eSIM* is sometimes incorrectly used for referring to the MFF2 physical form factor of an [eUICC](#euicc) chip that is designed to be permanently surface-mounted inside a device.
+Within the IoT industry, *eSIM* refers to the entire solution that is comprised of an eUICC-equipped [SIM](#sim) along with the software platform for [OTA provisioning](#ota-provisioning).
 Although eSIMs can be embedded directly in a device, they are also manufactured as pluggable SIM cards.
 The [emnify eSIM](/services/global-iot-sim) has capabilities not available with other eSIMs.
 
 ## eUICC
 _Embedded Universal Integrated Circuit Card_  
-The embedded universal integrated circuit card (eUICC) is a component of a [SIM](#sim---subscriber-identification-module) card.
-It allows consumers and IoT manufacturers to provision the SIM with a new [operator profile](https://www.emnify.com/iot-glossary/mno) [over-the-air](#ota---over–the–air).
+The embedded universal integrated circuit card (eUICC) is a component of a [SIM](#sim) card.
+It allows consumers and IoT manufacturers to provision the SIM with a new [operator profile](https://www.emnify.com/iot-glossary/mno) [over-the-air](#ota).
 
 :::tip Deep dive
 Learn more about the eUICC in our blog post: [What is an eUICC and why does it matter?](https://www.emnify.com/iot-glossary/what-is-an-euicc)
@@ -132,7 +132,7 @@ SIM cards vary in size (Mini vs. Micro vs. Nano), function (embedded vs. standar
 
 ## GGSN
 _Gateway GPRS Support Node_  
-Part of the [GSM](#gsm---global-system-for-mobile-communications) infrastructure, the [GGSN](#ggsn---gateway-gprs-support-node) is responsible for the interworking between the GPRS network and external packet switched networks.
+Part of the [GSM](#gsm) infrastructure, the [GGSN](#ggsn) is responsible for the interworking between the GPRS network and external packet switched networks.
 
 ## Globally–distributed infrastructure  
 Cloud infrastructure that is distributed globally, with several local breakout points for better traffic handling.
@@ -145,7 +145,7 @@ A standard developed by the European Telecommunications Standards Institute to d
 _Home Location Register_
 
 A database from a mobile network in which information from all mobile subscribers is stored.
-Part of [GSM](#gsm---global-system-for-mobile-communications) infrastructure. 
+Part of [GSM](#gsm) infrastructure. 
 
 ## HTTP POST request  
 A request method supported by the HTTP protocol, which typically includes data in the request body.
@@ -153,7 +153,7 @@ A request method supported by the HTTP protocol, which typically includes data i
 ## IC
 _Integrated Circuit_
 
-A semiconductor chip containing a large number of extremely small electronic components, e.g., a CPU, the chips on computer memory cards, the electronic part of a [SIM](#sim---subscriber-identification-module) card, an [eUICC](#euicc---embedded-universal-integrated-circuit-card), etc.
+A semiconductor chip containing a large number of extremely small electronic components, e.g., a CPU, the chips on computer memory cards, the electronic part of a [SIM](#sim) card, an [eUICC](#euicc), etc.
 
 ## ICCID
 _Integrated Circuit Card Identifier_
@@ -174,12 +174,12 @@ _International Mobile Equipment Identity_
 A unique number used to identify cellular modems.
 
 ## IMEI lock  
-The practice of strictly associating a SIM to the device with a certain [IMEI](#imei---international-mobile-equipment-identity) number.
+The practice of strictly associating a SIM to the device with a certain [IMEI](#imei) number.
 
 ## IMSI
 _International Mobile Subscriber Identity_
 
-A unique number used to identify a [GSM](#gsm---global-system-for-mobile-communications) subscriber.
+A unique number used to identify a [GSM](#gsm) subscriber.
 
 ## IPsec  
 A protocol suite for Secure Internet Protocol (IP) communications that works by authenticating and encrypting each IP packet of a communication session.
@@ -210,7 +210,7 @@ A unique number used to identify a mobile phone number internationally.
 ## MSC
 _Mobile Switching Center_
 
-The part of [GSM](#gsm---global-system-for-mobile-communications) architecture that controls the network switching subsystem elements.
+The part of [GSM](#gsm) architecture that controls the network switching subsystem elements.
 
 ## OTA
 _Over–the–Air_
@@ -267,9 +267,9 @@ A profile that defines the services and functionality of a device managed throug
 ## SIM
 _Subscriber Identification Module_
 
-A subscriber identification module (SIM) contains an integrated circuit ([IC](#ic---integrated-circuit)) that is often mounted on a plastic card.
+A subscriber identification module (SIM) contains an integrated circuit ([IC](#ic)) that is often mounted on a plastic card.
 Pluggable SIMs mounted on plastic cards are offered in various form factors.
-A SIM stores data used to identify a subscriber ([IMSI](#imsi---international-mobile-subscriber-identity)) along with other network information for connecting and authenticating with a [mobile network operator (MNO)](https://www.emnify.com/iot-glossary/mno).
+A SIM stores data used to identify a subscriber ([IMSI](#imsi)) along with other network information for connecting and authenticating with a [mobile network operator (MNO)](https://www.emnify.com/iot-glossary/mno).
 See also [eSIM - Embedded SIM](#esim---embedded-sim).
 
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -4,7 +4,9 @@
 When a SIM is in the active state, the charges for the SIM are applied.
 The device can send and receive data and SMS.
 
-## APN - Access point name  
+## APN
+_Access Point Name_
+
 A gateway between a [GSM](#gsm---global-system-for-mobile-communications), GPRS, 3G, or 4G mobile network and another computer network, usually the public Internet.
 The APN needs to be configured on the device. For emnify, it is `em` or `emnify`.
 
@@ -12,7 +14,9 @@ The APN needs to be configured on the device. For emnify, it is `em` or `emnify`
 A unique identification key used to authenticate emnify's APIs.
 Also used when authenticating the [OpenVPN](#openvpn) service.
 
-## A2P SMS - Application–to–peer SMS  
+## A2P SMS
+_Application–to–Peer SMS_
+
 SMS between an application and a device or vice-versa.
 
 ## Assigned SIM  
@@ -21,10 +25,14 @@ SIM that has been assigned to an [endpoint](#endpoint).
 ## AT+CREG AT command 
 Gives information about the registration status and access technology of the serving cell.
 
-## AuC - Authentication center  
+## AuC
+_Authentication Center_
+
 A part of [GSM](#gsm---global-system-for-mobile-communications) infrastructure, validates any SIM card attempting network connection when a phone has a live network signal.
 
-## BIC - Batch identification code  
+## BIC
+_Batch Identification Code_
+
 A unique code for ordered SIM cards used to register the SIM cards on the [**SIM Inventory** page of the emnify Portal](https://portal.emnify.com/sim-inventory).
 
 ## Callback URL  
@@ -54,20 +62,28 @@ Data transmitted by the device.
 ## Data usage (volume)  
 The data that has been used by an endpoint, both transmitted and received.
 
-## DDoS - Distributed denial of service attack  
+## DDoS
+_Distributed Denial of Service Attack_
+
 An attack where the attacker sends multiple requests to a web resource with the aim of exceeding the website’s capacity to handle multiple requests and prevent the website from functioning correctly.
 
-## DNS - Domain name system  
+## DNS
+_Domain Name System_
+
 A hierarchical decentralized naming system for computers, services, or any resource connected to the Internet or a private network to map a hostname to an IP address.
 
 ## Dynamic IP  
 An IP that changes over time.
 
-## eDRX - Extended discontinuous reception  
+## eDRX
+_Extended Discontinuous Reception_
+
 A device configuration that specifies the periodicity in which the device listens for incoming data on the radio.
 Instead of using a periodicity of 2.56ms (DRX) it can be increased up to 40mins, thus reducing power consumption.
 
-## EID - eUICC Identifier
+## EID
+_eUICC Identifier_
+
 The eUICC Identifier (EID) provides a unique global serial number for an [eUICC](#euicc---embedded-universal-integrated-circuit-card).
 It has a fixed length of 32 digits, as indicated in the following diagram:
 
@@ -86,13 +102,16 @@ A representation of the device which has a SIM installed.
 ## Endpoint status  
 The current state of the [endpoint](#endpoint): **Enabled** or **Disabled**.
 
-## eSIM - Embedded SIM
+## eSIM
+_Embedded SIM_
+
 Because of the "e" (for *embedded*) in its name, *eSIM* is sometimes incorrectly used for referring to the MFF2 physical form factor of an [eUICC](#euicc---embedded-universal-integrated-circuit-card) chip that is designed to be permanently surface-mounted inside a device.
 Within the IoT industry, *eSIM* refers to the entire solution that is comprised of an eUICC-equipped [SIM](#sim---subscriber-identification-module) along with the software platform for [OTA provisioning](#ota-provisioning).
 Although eSIMs can be embedded directly in a device, they are also manufactured as pluggable SIM cards.
 The [emnify eSIM](/services/global-iot-sim) has capabilities not available with other eSIMs.
 
-## eUICC - Embedded universal integrated circuit card  
+## eUICC
+_Embedded Universal Integrated Circuit Card_  
 The embedded universal integrated circuit card (eUICC) is a component of a [SIM](#sim---subscriber-identification-module) card.
 It allows consumers and IoT manufacturers to provision the SIM with a new [operator profile](https://www.emnify.com/iot-glossary/mno) [over-the-air](#ota---over–the–air).
 
@@ -111,26 +130,34 @@ SIM cards vary in size (Mini vs. Micro vs. Nano), function (embedded vs. standar
 - **3FF**: Micro SIM card
 - **4FF**: Nano SIM card
 
-## GGSN - Gateway GPRS support node  
+## GGSN
+_Gateway GPRS Support Node_  
 Part of the [GSM](#gsm---global-system-for-mobile-communications) infrastructure, the [GGSN](#ggsn---gateway-gprs-support-node) is responsible for the interworking between the GPRS network and external packet switched networks.
 
 ## Globally–distributed infrastructure  
 Cloud infrastructure that is distributed globally, with several local breakout points for better traffic handling.
 
-## GSM - Global system for mobile communications  
+## GSM
+_Global System for Mobile Communications_ 
 A standard developed by the European Telecommunications Standards Institute to describe the protocols for second-generation digital cellular networks used by mobile devices.
 
-## HLR - Home location register  
+## HLR
+_Home Location Register_
+
 A database from a mobile network in which information from all mobile subscribers is stored.
 Part of [GSM](#gsm---global-system-for-mobile-communications) infrastructure. 
 
 ## HTTP POST request  
 A request method supported by the HTTP protocol, which typically includes data in the request body.
 
-## IC - Integrated circuit
+## IC
+_Integrated Circuit_
+
 A semiconductor chip containing a large number of extremely small electronic components, e.g., a CPU, the chips on computer memory cards, the electronic part of a [SIM](#sim---subscriber-identification-module) card, an [eUICC](#euicc---embedded-universal-integrated-circuit-card), etc.
 
-## ICCID - Integrated circuit card identifier  
+## ICCID
+_Integrated Circuit Card Identifier_
+
 The integrated circuit card identifier (ICCID) is a 20-digit code used to identify a SIM card. 
 It includes a SIM card's country, home network, and identification number, as indicated in the following diagram:
 
@@ -141,13 +168,17 @@ Following the introduction of [eUICC](#euicc---embedded-universal-integrated-cir
 For example, the ICCID value can change when a different [SIM profile](#sim-profile) is provisioned on the eSIM.
 :::
 
-## IMEI - International mobile equipment identity 
+## IMEI
+_International Mobile Equipment Identity_
+
 A unique number used to identify cellular modems.
 
 ## IMEI lock  
 The practice of strictly associating a SIM to the device with a certain [IMEI](#imei---international-mobile-equipment-identity) number.
 
-## IMSI - International mobile subscriber identity  
+## IMSI
+_International Mobile Subscriber Identity_
+
 A unique number used to identify a [GSM](#gsm---global-system-for-mobile-communications) subscriber.
 
 ## IPsec  
@@ -156,24 +187,34 @@ A protocol suite for Secure Internet Protocol (IP) communications that works by 
 ## IP subnet  
 A logical subdivision of an IP network.
 
-## JSON - JavaScript object notation  
+## JSON
+_JavaScript Object Notation_
+
 A lightweight data-interchange format.
 It is easier for humans to read and write compared to other formats.
 It is easy for machines to parse and generate.
 
-## LAC - Location area code  
+## LAC
+_Location Area Code_
+
 A unique 16-digit fixed-length location area identity code that identifies a phone number’s location area.
 
 ## MFA Key  
 A combination generated by an external device or a service that is used to authenticate the user.
 
-## MSISDN - Mobile station international subscriber directory number  
+## MSISDN
+_Mobile Station International Subscriber Directory Number_
+
 A unique number used to identify a mobile phone number internationally.
 
-## MSC - Mobile Switching Center  
+## MSC
+_Mobile Switching Center_
+
 The part of [GSM](#gsm---global-system-for-mobile-communications) architecture that controls the network switching subsystem elements.
 
-## OTA - Over–the–air  
+## OTA
+_Over–the–Air_
+
 A method of wireless distribution of the software, configuration settings, or encryption keys.
 
 ## OTA Provisioning  
@@ -186,7 +227,9 @@ An open-source software application that implements [virtual private network (VP
 [emnify hosts an OpenVPN service](/services/openvpn) that allows you to establish a private network between a device and any remote client location.
 :::
 
-## P2P SMS - Peer–to–Peer SMS  
+## P2P SMS
+_Peer–to–Peer SMS_
+
 SMS exchanged between devices.
 
 ## PDP context  
@@ -196,7 +239,9 @@ Data structure present on both the serving GPRS support node (SGSN) and the [gat
 An IP address that is not reachable from the public Internet but only through a local or virtual network.
 [Dynamic private IPs](#dynamic-ip) keep changing, whereas static private IP addresses don't change.
 
-## PSM - Power saving mode  
+## PSM
+_Power Saving Mode_
+
 While in PSM, the device tells the network that it will power off for a specific time and will send periodic updates in longer-than-usual intervals.
 When the device comes back online, it does not need to reattach to a network but can use an already-created PDP context, thus saving power.
 
@@ -206,16 +251,22 @@ An IP address accessible from the public Internet.
 ## RESTful API
 The representational state transfer application programming interface allows you to integrate services with your applications.
 
-## SASE - Secure access service edge  
+## SASE
+_Secure Access Service Edge_
+
 SASE is a term coined by Gartner which combines software-defined networking ([SDN](#sdn)) and security and serves it as cloud-based Security-as-a-Service.
 
-## SDN - Software–defined networking  
+## SDN
+_Software–Defined Networking_
+
 An approach that allows network administrators to programmatically initialize, control, change and manage network behavior dynamically via open interfaces.
 
 ## Service profile  
 A profile that defines the services and functionality of a device managed through the emnify platform.
 
-## SIM - Subscriber identification module
+## SIM
+_Subscriber Identification Module_
+
 A subscriber identification module (SIM) contains an integrated circuit ([IC](#ic---integrated-circuit)) that is often mounted on a plastic card.
 Pluggable SIMs mounted on plastic cards are offered in various form factors.
 A SIM stores data used to identify a subscriber ([IMSI](#imsi---international-mobile-subscriber-identity)) along with other network information for connecting and authenticating with a [mobile network operator (MNO)](https://www.emnify.com/iot-glossary/mno).
@@ -237,7 +288,9 @@ The [mobile network operator (MNO)](https://www.emnify.com/iot-glossary/mno) ID 
 ## SIM repository  
 All SIMs assigned to your organization.
 
-## SMPP - Short Message Peer–to–Peer  
+## SMPP
+_Short Message Peer–to–Peer_
+
 A protocol used by the telecommunications industry for exchanging SMS messages between short message service centers (SMSC) and/or external short messaging entities (ESME).
 
 ## SMS console  
@@ -273,14 +326,20 @@ An ability to select which operator the customer’s SIM connects to.
 ## User–defined networking  
 An approach that enables users to create their own virtual mobile network, define service and security policies and provision [tariff profiles](#tariff-profile) and data packages.
 
-## USSD - Unstructured supplementary service data  
+## USSD
+_Unstructured Supplementary Service Data_
+
 A protocol used to communicate with the service provider’s computers.
 
 ## USSD gateway  
 The collection of hardware and software required to interconnect two or more disparate networks, including performing protocol conversion.
 
-## VPC - Virtual private cloud
+## VPC
+_Virtual Private Cloud_
+
 A secure private cloud hosted within a public cloud where you can host websites, store data, run applications, etc.
 
-## VPN - Virtual private network
+## VPN
+_Virtual Private Network_
+
 A service that protects your internet connection and privacy online.

--- a/docs/quickstart/devices/getting-the-first-device-online.md
+++ b/docs/quickstart/devices/getting-the-first-device-online.md
@@ -6,7 +6,7 @@ description: APN (Access Point Name) configuration is the first step
 Any device equipped with a SIM card requires an Access Point Name (APN) configuration to establish a data session.
 Some devices and networks auto-detect the APN but for most cases you need to configure it.
 
-[APN](/glossary#apn---access-point-name): `em` (or alternatively use `emnify`)
+[APN](/glossary#apn): `em` (or alternatively use `emnify`)
 
 Further, some Android / iOS-based devices and cellular modules also need to be configured to allow for roaming.
 

--- a/docs/quickstart/registering-sims.md
+++ b/docs/quickstart/registering-sims.md
@@ -14,7 +14,7 @@ If you order the free Evaluation SIM package, you will have to register each of 
   style={{ width: 292 }}
 />
 
-1. Since the **Single-SIM registration** is already selected by default, enter the [Batch Identification Code](/glossary#bic---batch-identification-code) (**BIC1**) in the prompt:  
+1. Since the **Single-SIM registration** is already selected by default, enter the [Batch Identification Code](/glossary#bic) (**BIC1**) in the prompt:  
 <img
   src={require('./assets/portal-sim-registration-enter-bic1.png').default}
   style={{width:350}} alt=""

--- a/docs/services/events/event-types.md
+++ b/docs/services/events/event-types.md
@@ -1424,7 +1424,7 @@ SIM is patched from **Issued** to **Factory Test** status (for SIM testing).
 
 ### SIM registration
 
-SIM or SIM batch is registered to an organization via a [Batch Identification Code (BIC)](/glossary#bic---batch-identification-code). 
+SIM or SIM batch is registered to an organization via a [Batch Identification Code (BIC)](/glossary#bic). 
 
 :::note
 This event doesn't trigger when the emnify team assigns SIMs to an organization.

--- a/docs/services/global-iot-sim.md
+++ b/docs/services/global-iot-sim.md
@@ -5,7 +5,7 @@ description: Form factors, quality grades, multi-IMSI, eSIM, eUICC
 
 emnify provides eSIMs that are built specifically for IoT solutions.
 Compared to regular operator SIMs, emnify eSIMs come in different quality grades that are more durable.
-They can be updated [over the air (OTA)](/glossary#ota---overtheair) using different eSIM remote SIM provisioning technologies and come in different [form factors](#form-factors).
+They can be updated [over the air (OTA)](/glossary#ota) using different eSIM remote SIM provisioning technologies and come in different [form factors](#form-factors).
 
 emnify eSIMs have a [multi-IMSI applet](#multi-imsi-applet) installed on the SIM.
 The multi-IMSI applet makes sure that the best network and network partners are used based a device's location.
@@ -16,7 +16,7 @@ Using this technology, emnify provides a larger number of networks than traditio
 ### M2M eSIM
 
 Every new SIM you order from emnify is an [M2M eSIM](https://www.gsma.com/esim/remote-sim-provisioning-for-machine-to-machine/) (compliant with SGP.01, SGP.02, and SGP.016).
-The M2M eSIM is also referred to as an [eUICC](/glossary#euicc---embedded-universal-integrated-circuit-card) (Embedded universal integrated circuit card).
+The M2M eSIM is also referred to as an [eUICC](/glossary#euicc) (Embedded universal integrated circuit card).
 Unlike a regular SIM (UICC), an eUICC can be updated over the air.
 Because M2M eSIMs can be updated with new configurations or profiles, this eliminates the need for SIM swaps.
 
@@ -238,7 +238,7 @@ An emnify eSIM has cellular provider information from multiple SIM cards already
 While emnify has roaming agreements and local contracts with operators around the world, emnify also uses partner operators to increase the network coverage footprint in order to provide a fallback when preferred networks experience outages.
 
 The multi-IMSI applet works in the following manner.
-emnify has its own operator identity ([IMSI](/glossary#imsi---international-mobile-subscriber-identity)) as well as the partner operator's IMSI stored on the SIM card.
+emnify has its own operator identity ([IMSI](/glossary#imsi)) as well as the partner operator's IMSI stored on the SIM card.
 Each IMSI / partner operator usually has more than one network accessible per country.
 The applet also includes a preferred IMSI list per country.
 For example, this list defines that IMSI *X* will have the highest priority for access in country *A*.

--- a/docs/services/security.md
+++ b/docs/services/security.md
@@ -11,11 +11,11 @@ emnify uses a SASE approach to simplify securing devices – using several servi
 
 ![IoT security threats](assets/security-threats.png)
 
-Secure Access Service Edge ([SASE](/glossary#sase---secure-access-service-edge)) introduces a new architecture where networking and security functions are bundled in a cloud-delivered service.
+Secure Access Service Edge ([SASE](/glossary#sase)) introduces a new architecture where networking and security functions are bundled in a cloud-delivered service.
 You can apply the same security standards across all your devices independent of the location.
 Moreover, you can integrate security features in your solutions right from the beginning.
 
-Some of the features that [SASE](/glossary#sase---secure-access-service-edge) for IoT architecture includes are as follows:
+Some of the features that [SASE](/glossary#sase) for IoT architecture includes are as follows:
 
 - Dynamic Data Routing with Software-Defined Wide Area Network (SD-WAN)  
 emnify utilizes a SD-WAN to route data to the closest cloud region using the [Regional Breakout](iot-cloud-communication-platform#regional-breakout) concept.
@@ -65,7 +65,7 @@ A tutorial on how to set up a DNS firewall based on a private DNS using Amazon R
 
 For device manufacturers, SIM card theft is an issue because pluggable SIM cards can be removed from a device and then used to gain free internet access.
 The [IMEI lock](/glossary#imei-lock)  feature prevents the use of SIM card in any other device by bounding the SIM to an IMEI.
-The [IMEI](/glossary#imei---international-mobile-equipment-identity) is a unique device identifier.
+The [IMEI](/glossary#imei) is a unique device identifier.
 When the automatic IMEI lock is configured, the emnify platform will bind the SIM cards to the first device that establishes a data connection.
 All future device connections will only be allowed from this device.
 


### PR DESCRIPTION
### Description

Clean up based on a discussion with @techwriter-dev on Slack where he noted:

> In an older PR related to the Glossary you once asked in a conversation about whether or not to include the expanded meaning of acronyms in the section heading.
>
> I am against the current practice of including it for a couple of reasons:
> 1. Internal anchors are way too long: `[IMEI](#imei---international-mobile-equipment-identity)`
> 2. It clutters the view and makes a quick skimming of the text body (or page contents pane) more difficult.
>
> Also, I noticed that en-dashes (maybe even em-dashes?) are sometimes used as hyphens.

🧹 🧹 🧹 

<img width="767" alt="Screenshot 2023-03-30 at 10 46 02" src="https://user-images.githubusercontent.com/26869552/228782421-302cb6c8-3189-4927-b59b-e107e99e0435.png">

### Additional context

Internal ticket 🎫  [SDOCS-334](https://emnify.atlassian.net/browse/SDOCS-334)

[SDOCS-334]: https://emnify.atlassian.net/browse/SDOCS-334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ