### PR TITLE
Migrate SDK category to top-level navigation

### DIFF
--- a/docs/sdks/index.md
+++ b/docs/sdks/index.md
@@ -1,0 +1,16 @@
+---
+slug: /sdks
+---
+
+# emnify SDKs
+
+The emnify software development kits (SDKs) allow developers to manage their IoT devices using an intuitive set of APIs, including SIM state management and device connectivity operations.
+
+:::tip
+The [Concepts](/sdks/concepts) page covers helpful terms to know while working with our SDKs.
+:::
+
+## Available languages
+
+- [Python](/sdks/python)
+- [Java](/sdks/java)

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -135,6 +135,12 @@ const config = {
             sidebarId: "graphqlSidebar",
             label: "GraphQL API",
           },
+          {
+            type: "docSidebar",
+            position: "left",
+            sidebarId: "sdkSidebar",
+            label: "SDKs",
+          },
         ],
       },
       docs: {

--- a/sidebars.js
+++ b/sidebars.js
@@ -117,70 +117,6 @@ const sidebars = {
     },
     {
       type: "category",
-      label: "Software Development Kits",
-      link: {
-        type: "generated-index",
-        title: "emnify SDKs",
-        description:
-          "The emnify software development kits (SDKs) allow developers to manage their IoT devices using an intuitive set of APIs, including SIM state management and device connectivity operations",
-        slug: "/sdks",
-      },
-      items: [
-        "sdks/concepts",
-        {
-          type: "category",
-          label: "Python",
-          link: {
-            type: "generated-index",
-            title: "emnify Python SDK",
-            description:
-              "The emnify Python software development kit (SDK) for SIM state management and device connectivity operations",
-            slug: "/sdks/python",
-          },
-          items: [
-            {
-              type: "doc",
-              label: "Getting started",
-              id: "sdks/python/getting-started",
-            },
-            "sdks/python/examples",
-            "sdks/python/help",
-            {
-              type: "link",
-              label: "API Reference",
-              href: "https://emnify.github.io/emnify-sdk-python/autoapi/index.html",
-            },
-          ],
-        },
-        {
-          type: "category",
-          label: "Java",
-          link: {
-            type: "generated-index",
-            title: "emnify Java SDK",
-            description:
-              "The emnify Java software development kit (SDK) for SIM state management and device connectivity operations",
-            slug: "/sdks/java",
-          },
-          items: [
-            {
-              type: "doc",
-              label: "Getting started",
-              id: "sdks/java/getting-started",
-            },
-            "sdks/java/examples",
-            "sdks/java/help",
-            {
-              type: "link",
-              label: "API Reference",
-              href: "https://emnify.github.io/emnify-sdk-java/",
-            },
-          ],
-        },
-      ],
-    },
-    {
-      type: "category",
       label: "Single Sign-On",
       link: {
         type: "generated-index",
@@ -256,6 +192,64 @@ const sidebars = {
       id: "graphql/preview",
     },
     "graphql/using-graphiql",
+  ],
+  sdkSidebar: [
+    {
+      type: "doc",
+      label: "Getting started",
+      id: "sdks/index",
+    },
+    "sdks/concepts",
+    {
+      type: "category",
+      label: "Python",
+      link: {
+        type: "generated-index",
+        title: "emnify Python SDK",
+        description:
+          "The emnify Python software development kit (SDK) for SIM state management and device connectivity operations",
+        slug: "/sdks/python",
+      },
+      items: [
+        {
+          type: "doc",
+          label: "Getting started",
+          id: "sdks/python/getting-started",
+        },
+        "sdks/python/examples",
+        "sdks/python/help",
+        {
+          type: "link",
+          label: "API Reference",
+          href: "https://emnify.github.io/emnify-sdk-python/autoapi/index.html",
+        },
+      ],
+    },
+    {
+      type: "category",
+      label: "Java",
+      link: {
+        type: "generated-index",
+        title: "emnify Java SDK",
+        description:
+          "The emnify Java software development kit (SDK) for SIM state management and device connectivity operations",
+        slug: "/sdks/java",
+      },
+      items: [
+        {
+          type: "doc",
+          label: "Getting started",
+          id: "sdks/java/getting-started",
+        },
+        "sdks/java/examples",
+        "sdks/java/help",
+        {
+          type: "link",
+          label: "API Reference",
+          href: "https://emnify.github.io/emnify-sdk-java/",
+        },
+      ],
+    },
   ],
 };
 


### PR DESCRIPTION
### Description

We've discussed it a bunch and referenced it in internal docs, so thought we should just... do it ✨ 💻 🐍 ☕ 

### Visual preview

<img width="1218" alt="Screenshot 2023-04-24 at 14 24 38" src="https://user-images.githubusercontent.com/26869552/233996717-8a1d31da-98e6-420c-92b4-3749a8dcd5a7.png">

### Additional context

So that we didn't need to create any redirects or end up with broken links, I converted the [original SDK category's `generated-index`](https://docs.emnify.com/sdks) into a new `index.md` file.
