### PR TITLE
Standardize how we refer to API references in admonitions

### DIFF
--- a/docs/services/data-streamer/stream-types.md
+++ b/docs/services/data-streamer/stream-types.md
@@ -132,7 +132,7 @@ Usage records for data are created:
 </details>
 
 :::note API Reference
-[Usage Object - Data Streamer API Reference Documentation](https://cdn.emnify.net/api/doc/data-streamer.html#usage-object)
+[Data Streamer Usage Object - emnify REST API](https://cdn.emnify.net/api/doc/data-streamer.html#usage-object)
 :::
 
 #### SMS
@@ -219,5 +219,5 @@ Usage records for SMS are created when an SMS is successfully delivered either:
 </details>
 
 :::note API Reference
-[Usage Object - Data Streamer API Reference Documentation](https://cdn.emnify.net/api/doc/data-streamer.html#usage-object)
+[Data Streamer Usage Object - emnify REST API](https://cdn.emnify.net/api/doc/data-streamer.html#usage-object)
 :::

--- a/docs/services/data-streamer/usage.md
+++ b/docs/services/data-streamer/usage.md
@@ -236,7 +236,7 @@ You can also create an event stream with [AWS Kinesis integration](available-int
 ```
 
 :::note API Reference
-[emnify API specification - Create Data Stream](https://cdn.emnify.net/api/doc/swagger.html#/Integrations/CreateDataStreamer).
+[Create Data Stream - emnify REST API](https://cdn.emnify.net/api/doc/swagger.html#/Integrations/CreateDataStreamer).
 :::
 
 ### Listing data streams
@@ -252,7 +252,7 @@ curl -X GET "https://cdn.emnify.net/api/v2/data_stream" \
 ```
 
 :::note API Reference
-[emnify API specification - List Data Stream configurations of your organization](https://cdn.emnify.net/api/doc/swagger.html#/Integrations/ListDataStreamerV2s)
+[List data stream configurations of your organization - emnify REST API](https://cdn.emnify.net/api/doc/swagger.html#/Integrations/ListDataStreamerV2s)
 :::
 
 ### Retrieving details
@@ -270,7 +270,7 @@ curl -X GET "https://cdn.emnify.net/api/v2/data_stream/123" \
 ```
 
 :::note API Reference
-[emnify API specification - Get Details on Existing Data Stream](https://cdn.emnify.net/api/doc/swagger.html#/Integrations/GetDataStreamerByIdV2)
+[Get Details on Existing Data Stream - emnify REST API](https://cdn.emnify.net/api/doc/swagger.html#/Integrations/GetDataStreamerByIdV2)
 :::
 
 ### Updating data streams
@@ -302,7 +302,7 @@ The following example shows how to pause a stream and erase any filters:
 ```
 
 :::note API Reference
-[emnify API specification - Modify Existing Data Stream](https://cdn.emnify.net/api/doc/swagger.html#/Integrations/PatchV2DataStream)
+[Modify Existing Data Stream - emnify REST API](https://cdn.emnify.net/api/doc/swagger.html#/Integrations/PatchV2DataStream)
 :::
 
 ### Deleting data streams
@@ -320,5 +320,5 @@ curl -X DELETE "https://cdn.emnify.net/api/v2/data_stream/123" \
 ```
 
 :::note API Reference
-[emnify API specification - Delete Existing Data Stream](https://cdn.emnify.net/api/doc/swagger.html#/Integrations/DeleteDataStreamerV2)
+[Delete Existing Data Stream - emnify REST API](https://cdn.emnify.net/api/doc/swagger.html#/Integrations/DeleteDataStreamerV2)
 :::

--- a/docs/services/events/event-types.md
+++ b/docs/services/events/event-types.md
@@ -7,7 +7,7 @@ description: List of all available event types
 The following is a list of available event types, including their corresponding IDs and descriptions.
 
 :::note API Reference
-[Event Type Object - Event API Reference Documentation](https://cdn.emnify.net/api/doc/event.html#event-type-object)
+[Event Type Object - emnify REST API](https://cdn.emnify.net/api/doc/event.html#event-type-object)
 :::
 
 ## Generic events

--- a/docs/services/events/getting-started.md
+++ b/docs/services/events/getting-started.md
@@ -35,7 +35,7 @@ Events are distinguished by three severity levels:
 * **Critical**: Serious issue that likely requires additional follow-up (e.g., charging for an invoice failed).
 
 :::note API Reference 
-[Event Severity Object - Event API Reference Documentation](https://cdn.emnify.net/api/doc/event.html#event-severity-object)
+[Event Severity Object - emnify REST API](https://cdn.emnify.net/api/doc/event.html#event-severity-object)
 :::
 
 ### Event source
@@ -54,7 +54,7 @@ That's because the Portal is an interface that uses the API under the hood.
 ::: 
 
 :::note API Reference
-[Event Source Object - Event API Reference Documentation](https://cdn.emnify.net/api/doc/event.html#event-source-object)
+[Event Source Object - emnify REST API](https://cdn.emnify.net/api/doc/event.html#event-source-object)
 :::
 
 ### Event type


### PR DESCRIPTION
### Description

Smol cleanup as described by the PR title 🧹 but it's especially important now that we also have the GraphQL API in preview.

### Example visual ✨ 

<img width="719" alt="Screenshot 2023-05-24 at 19 26 01" src="https://github.com/emnify/product-docs/assets/26869552/819745a6-45a8-4857-abc2-6482a16c4670">

### Additional Context

No ticket 😇 