### PR TITLE
Remove the 'Edit this page' button

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -30,7 +30,6 @@ const config = {
         docs: {
           sidebarPath: require.resolve("./sidebars.js"),
           routeBasePath: "/",
-          editUrl: "https://github.com/emnify/product-docs/blob/main/",
           showLastUpdateTime: true,
         },
         theme: {


### PR DESCRIPTION
### Description

Most of the people interested in contributing to our documentation are internal (or, in some cases, not familiar with the GitHub workflow) and I've noticed that this button causes more confusion than it is helpful.

My proposal is to temporarily remove it and re-evaluate whether we want to show this on the page 🔪 

### Visual preview ✨ 

<img width="521" alt="Screenshot 2023-06-06 at 16 56 58" src="https://github.com/emnify/product-docs/assets/26869552/ff7048c7-e888-468c-9e65-b0f6c038ee33">

<details>
<summary>Before</summary>
<img width="622" alt="Screenshot 2023-06-06 at 16 57 28" src="https://github.com/emnify/product-docs/assets/26869552/518ab5d8-4d6f-4c88-81d0-408acbbf5f4f">
</details>
