### PR TITLE
Add permission tables to User management page based on EUI user guide

### DIFF
--- a/docs/portal/user-management.md
+++ b/docs/portal/user-management.md
@@ -19,11 +19,12 @@ That's why emnify offers 3 levels of access (referred to as **Roles**) to use an
 
 You can view and edit these roles on the [**Employees** page](https://portal.emnify.com/organisation-settings/users) under your **Organization settings**. 
 
-The following table describes the permissions for different roles.
+The following tables describe the permissions for different roles.
+
+## Endpoint management
 
 | Action | Admin | Observer | User |
 | ------ | :---: | :------: | :--: |
-| **Endpoint management** ||||
 | Retrieve an endpoint by ID | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> |
 | Update, Delete an endpoint by ID | <img src={Check} alt="✓" /> | <img src={Uncheck} alt="×" /> | <img src={Check} alt="✓" /> |
 | Retrieve the blacklisted Operators for an Endpoint | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> |
@@ -31,12 +32,20 @@ The following table describes the permissions for different roles.
 | List all Endpoints | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> |
 | Create new endpoint | <img src={Check} alt="✓" /> | <img src={Uncheck} alt="×" /> | <img src={Check} alt="✓" /> |
 | Retrieve connectivity information of an Endpoint | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> |
-| **SIM management** ||||
+
+## SIM management
+
+| Action | Admin | Observer | User |
+| ------ | :---: | :------: | :--: |
 | Retrieve SIMs by ID | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> |
 | Update, Delete SIMs by ID | <img src={Check} alt="✓" /> | <img src={Uncheck} alt="×" /> | <img src={Check} alt="✓" /> |
 | List available SIM Statuses | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> |
 | List of available SIMs | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> |
-| **Service profile** ||||
+
+## Service profile
+
+| Action | Admin | Observer | User |
+| ------ | :---: | :------: | :--: |
 | Retrieve list of available Countries | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> |
 | Retrieve list of available Currencies | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> |
 | Retrieve single Currency details by ID | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> |
@@ -49,3 +58,56 @@ The following table describes the permissions for different roles.
 | Add, Delete services from Service Profiles | <img src={Check} alt="✓" /> | <img src={Uncheck} alt="×" /> | <img src={Check} alt="✓" /> |
 | Add, Delete Traffic Limit from Service | <img src={Check} alt="✓" /> | <img src={Uncheck} alt="×" /> | <img src={Check} alt="✓" /> |
 | Retrieve the ESME interface types | <img src={Check} alt="✓" /> | <img src={Uncheck} alt="×" /> | <img src={Check} alt="✓" /> |
+
+## Tariff profile
+
+| Action | Admin | Observer | User |
+| ------ | :---: | :------: | :--: |
+| List of available Ratezone Statuses | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> |
+| List of available Tariff Statuses | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> |
+| Retrieve Tariff details by ID | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> |
+| Retrieve Tariffs | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> |
+| Retrieve list of tariff plan statuses | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> |
+| Create Tariff Profiles | <img src={Check} alt="✓" /> | <img src={Uncheck} alt="×" /> | <img src={Check} alt="✓" /> |
+| List Tariff Profiles | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> |
+| Retrieve Coverage of a Tariff Profile | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> |
+| Retrieve single Country details by ID | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> |
+| List Operators | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> |
+| Retrieve my currently active tariff plan | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> |
+
+## User management
+
+| Action | Admin | Observer | User |
+| ------ | :---: | :------: | :--: |
+| Create Support Token to assume permissions of a User by ID | <img src={Uncheck} alt="×" /> | <img src={Uncheck} alt="×" /> | <img src={Uncheck} alt="×" /> |
+| Update, Delete Users | <img src={Check} alt="✓" /> | <img src={Uncheck} alt="×" /> | <img src={Uncheck} alt="×" /> |
+| Retrieve my user role permissions | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> |
+| Update User password | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> |
+| Create, List Users | <img src={Check} alt="✓" /> | <img src={Uncheck} alt="×" /> | <img src={Uncheck} alt="×" /> |
+| Add, Delete Role from a User | <img src={Check} alt="✓" /> | <img src={Uncheck} alt="×" /> | <img src={Uncheck} alt="×" /> |
+| Delete, List trusted devices for a given user | <img src={Check} alt="✓" /> | <img src={Uncheck} alt="×" /> | <img src={Uncheck} alt="×" /> |
+| Create, Retrieve Application Token | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> |
+| Edit an Application Token | <img src={Check} alt="✓" /> | <img src={Uncheck} alt="×" /> | <img src={Uncheck} alt="×" /> |
+
+## Alerts
+
+| Action | Admin | Observer | User |
+| ------ | :---: | :------: | :--: |
+| Retrieve Organization/Endpoint Alerts | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> |
+| Retrieve events of a User by ID | <img src={Check} alt="✓" /> | <img src={Uncheck} alt="×" /> | <img src={Uncheck} alt="×" /> |
+| Retrieve events of an IMSI/SIM | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> |
+
+## MFA keys
+
+| Action | Admin | Observer | User |
+| ------ | :---: | :------: | :--: |
+| Generate user shared secret key for MFA | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> |
+| Activate user shared secret key for MFA | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> |
+| List available MFA Key Statuses | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> |
+| Delete shared secret key for MFA of a user by ID | <img src={Check} alt="✓" /> | <img src={Uncheck} alt="×" /> | <img src={Uncheck} alt="×" /> |
+| List of trusted devices for own user | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> |
+| Delete a trusted device by ID for own user | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> |
+| List of available MFA Key Types | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> |
+| Delete my shared secret for MFA | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> |
+| List of trusted devices for own user | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> |
+| Delete a trusted device for own user | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> | <img src={Check} alt="✓" /> |


### PR DESCRIPTION
### Description

Referenced the latest version of the emnify User Interface (EUI) user guide (v1.9) to add missing permission tables to the [User management](https://docs.emnify.com/portal/user-management) page. Also created individual tables for each category.

There's a lot that still needs to be updated on this page when it comes to the layout and styling 🥴  but adding these tables satisfies a request we received from the Support team, as the current page doesn't distinguish any differences between Admin and User roles.

### Additional Context

All references are internal, but happy to share if you ping me 📫 
