### PR TITLE
removed reference to the consumer eSIM based on input from CSM and Support

### DIFF
--- a/docs/services/connectivity/global-iot-sim.md
+++ b/docs/services/connectivity/global-iot-sim.md
@@ -23,12 +23,6 @@ The M2M eSIM is also referred to as an [embedded universal integrated circuit ca
 Unlike a regular SIM (UICC), an eUICC can be updated over the air.
 Because M2M eSIMs can be updated with new configurations or profiles, this eliminates the need for SIM swaps.
 
-### Consumer eSIM
-
-emnify also offers consumer eSIMs for phones, tablets, and smart watches.
-The consumer eSIM can be downloaded to a device by scanning a QR code.
-If you are interested in consumer eSIM technology, please [contact the emnify sales team](https://www.emnify.com/talk-to-us).
-
 ## Form factors
 
 emnify [M2M eSIMs](#m2m-esim) are available in the following form factors:


### PR DESCRIPTION


### Description

emnify no longer offers the consumer eSIM to its customers. Therefore we are removing the eSIM from the documentation. 

** Before **

![Screenshot 2023-08-09 at 18 01 01](https://github.com/emnify/product-docs/assets/45363541/f015693d-2735-40af-b705-3a0a8443ddf1)

** After **
![Screenshot 2023-08-09 at 18 02 08](https://github.com/emnify/product-docs/assets/45363541/1afec243-a839-4c0f-875a-3059c95f511d)
