### PR TITLE
Set minimum alert level to error on Vale CI

### DIFF
--- a/.github/vale/README.md
+++ b/.github/vale/README.md
@@ -24,12 +24,13 @@ vale .github/vale/README.md
 ### Alerts
 
 Vale has three alert options: `suggestion`, `warning`, and `error`.
-By default, the minimum alert level is set to `warning`.
+By default, the minimum alert level in the project configuration is set to `warning`.
 
-<!-- All Vale tests must pass for approval. -->
+Vale is run via a [CI pipeline](.github/workflows/vale.yml).
+This pipeline fails on `error` and doesn't report warnings or suggestions.
 
-> **Note** 
-> This repository is being migrated to Vale, so it's currently not integrated into the commit hooks or CI pipelines.
+> **Warning**
+> The 'Validate content with Vale' pipeline must pass for approval.
 
 ## Styles
 
@@ -97,3 +98,13 @@ We're also missing an Oxford comma in that sentence!
 Do not do this!
 <!-- vale on -->
 ```
+
+## Add a new Vale rule
+
+Every new Vale rule takes effort to create and enforce, so we want to be mindful of what we implement.
+
+In general, follow these guidelines:
+
+- If you add an error-level Vale rule, **you must fix the existing occurrences of the issue** in the documentation before you can add the rule.
+- If the number of additional alerts in the Vale output is significant after adding your rule, the rule might be too broad.
+- If the rule is too subjective and an author frequently ignores it, it can't be adequately enforced and creates unnecessary additional warnings.

--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -15,5 +15,6 @@ jobs:
       - uses: errata-ai/vale-action@reviewdog
         with:
           fail_on_error: true
+          vale_flags: '--minAlertLevel=error'
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -92,7 +92,7 @@ All Markdown and MDX files are linted using [Vale](https://vale.sh/).
 There's also an [EditorConfig](.editorconfig) file at the root of this repository to enforce consistent spacing and formatting.
 
 Vale is run via a [CI pipeline](.github/workflows/vale.yml) that fails on errors.
-See the [vale README](.github/vale/README.md) for more information.
+See the [Vale README](.github/vale/README.md) for more information.
 
 ## Display images
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -88,8 +88,11 @@ yarn prettier:fix
 
 ### Content
 
-All Markdown and MDX files are linted using [Vale](.github/vale/README.md).
+All Markdown and MDX files are linted using [Vale](https://vale.sh/).
 There's also an [EditorConfig](.editorconfig) file at the root of this repository to enforce consistent spacing and formatting.
+
+Vale is run via a [CI pipeline](.github/workflows/vale.yml) that fails on errors.
+See the [vale README](.github/vale/README.md) for more information.
 
 ## Display images
 


### PR DESCRIPTION
<!--
  Thanks for making a pull request!
  Please make sure your title is as descriptive as possible. It's important for commit hisotry as we squash on merge and use the pull request title as the commit message.

  Have any questions?
  Feel free to ask in this PR or you can also send us an email: docs@emnify.com
-->

### Description

Currently our Vale CI is failing on warning buuuuut it should only be failing on errors, so this PR adds a flag to make sure this is functioning properly 😇 

Bonus 🍬  Updated and adding some documentation related to the CI and adding new Vale rules!

