### PR TITLE
Run markdownlint on Java SDK Quickstart guide

### DIFF
--- a/docs/sdks/java/quickstart.md
+++ b/docs/sdks/java/quickstart.md
@@ -15,7 +15,7 @@ To install the SDK, add the emnify dependency to your existing project and use b
 
 :::caution
 Regardless of the package manager you are using, you need to specify the latest version of the emnify Java SDK.
-The following installation examples use *`SDK_VERSION`* where this should be specified.
+The following installation examples use _`SDK_VERSION`_ where this should be specified.
 :::
 
 ### Prerequisites
@@ -31,10 +31,10 @@ The following installation examples use *`SDK_VERSION`* where this should be spe
 
 Refer to the [SSL Report table](https://www.ssllabs.com/ssltest/analyze.html?d=cdn.emnify.net&latest) for the supported Transport Layer Security (TLS) versions.
 
-
 ### Install with Maven
 
 Use the following dependency in your project to grab via [Maven](https://maven.apache.org/download.cgi):
+
 ```xml
     <dependency>
         <groupId>com.emnify.sdk</groupId>
@@ -43,16 +43,17 @@ Use the following dependency in your project to grab via [Maven](https://maven.a
     </dependency>
 ```
 
-Replace *`SDK_VERSION`* with the version of the emnify Java SDK you're using.
+Replace _`SDK_VERSION`_ with the version of the emnify Java SDK you're using.
 
 ### Install with Gradle
 
 Use the following to add the emnify dependency to your project via [Gradle](https://gradle.org/install/):
+
 ```gradle
     implementation group: "com.emnify.sdk", name: "emnify", version: "SDK_VERSION"
 ```
 
-Replace *`SDK_VERSION`* with the version of the emnify Java SDK you're using.
+Replace _`SDK_VERSION`_ with the version of the emnify Java SDK you're using.
 
 ### Install manually
 
@@ -83,9 +84,8 @@ Here are some examples:
 | `EMNIFY_APPLICATION_TOKEN`  | Variable for authenticating via an [application token](/rest/authentication#authenticate-with-an-application-token). |
 | `EMNIFY_USERNAME` and `EMNIFY_PASSWORD` | Variables for authenticating via [username and password](/rest/authentication#authenticate-with-user-credentials). |
 
+## Explore more
 
-## Explore more 
-
-If you're new to IoT connectivity and emnify, start by learning some [common terminology and concepts](/sdks/concepts) and explore some [use cases](/sdks/java/examples) that show what the SDK is capable of. 
+If you're new to IoT connectivity and emnify, start by learning some [common terminology and concepts](/sdks/concepts) and explore some [use cases](/sdks/java/examples) that show what the SDK is capable of.
 
 Also, see the [emnify System Documentation](https://cdn.emnify.net/api/doc/index.html) and our [OpenAPI specification](https://cdn.emnify.net/api/doc/swagger.html).

--- a/docs/sdks/java/quickstart.md
+++ b/docs/sdks/java/quickstart.md
@@ -13,7 +13,7 @@ The emnify Java SDK is open source and the [source code is available on GitHub](
 
 To install the SDK, add the emnify dependency to your existing project and use build automation tools, like Maven or Gradle, or install it manually.
 
-:::caution
+:::info
 Regardless of the package manager you are using, you need to specify the latest version of the emnify Java SDK.
 The following installation examples use _`SDK_VERSION`_ where this should be specified.
 :::


### PR DESCRIPTION
### Description

Seems this step was missed in #153, so this is a small fix! 

Nothing should visibly change on the page, except the change of the first admonition to `info` (caution was a bit aggressive for flagging a placeholder).
