### PR TITLE
Manually input 'Last updated on' date to better reflect content status

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,3 +1,8 @@
+---
+last_update: 
+  date: 09-07-2023
+---
+
 # Glossary
 
 <!-- markdownlint-disable MD036 -->

--- a/docs/graphql/graphiql-ide.md
+++ b/docs/graphql/graphiql-ide.md
@@ -1,5 +1,7 @@
 ---
 displayed_sidebar: devResourcesSidebar
+last_update: 
+  date: 08-30-2023
 slug: /graphql/graphiql-ide
 ---
 

--- a/docs/graphql/preview.md
+++ b/docs/graphql/preview.md
@@ -1,10 +1,12 @@
 ---
 title: Preview the GraphQL API
-slug: /graphql
+displayed_sidebar: devResourcesSidebar
+last_update: 
+  date: 03-17-2023
 pagination_label: Preview the GraphQL API
 pagination_prev: rest/index
 pagination_next: graphql/graphiql-ide
-displayed_sidebar: devResourcesSidebar
+slug: /graphql
 ---
 
 # emnify GraphQL API <span className="theme-doc-version-badge badge badge--primary">preview</span>

--- a/docs/how-tos/data-allowances.md
+++ b/docs/how-tos/data-allowances.md
@@ -1,5 +1,7 @@
 ---
 description: How to change the assigned data allowance via the emnify Portal
+last_update: 
+  date: 09-07-2023
 slug: /how-tos/data-allowances
 ---
 

--- a/docs/how-tos/index.md
+++ b/docs/how-tos/index.md
@@ -1,5 +1,7 @@
 ---
 description: Step-by-step how to guides that teach you how to use the emnify platform
+last_update: 
+  date: 06-17-2023
 pagination_next: how-tos/data-allowances
 slug: /how-tos
 ---

--- a/docs/how-tos/sso/google-cloud-platform.md
+++ b/docs/how-tos/sso/google-cloud-platform.md
@@ -1,5 +1,7 @@
 ---
 description: Setup SSO for your emnify account with Google Cloud Platform
+last_update: 
+  date: 12-16-2022
 slug: /sso/google-cloud-platform
 ---
 

--- a/docs/how-tos/sso/microsoft-active-directory.md
+++ b/docs/how-tos/sso/microsoft-active-directory.md
@@ -1,5 +1,7 @@
 ---
 description: Setup SSO for your emnify account with Microsoft Active Directory
+last_update: 
+  date: 12-20-2022
 pagination_next: how-tos/sso/google-cloud-platform
 slug: /sso/microsoft-active-directory
 ---

--- a/docs/how-tos/sso/troubleshooting.md
+++ b/docs/how-tos/sso/troubleshooting.md
@@ -1,5 +1,7 @@
 ---
 description: Tips for combating common issues when setting up SSO for your emnify account
+last_update: 
+  date: 12-16-2022
 slug: /sso/troubleshooting
 ---
 

--- a/docs/how-tos/two-factor-authentication.md
+++ b/docs/how-tos/two-factor-authentication.md
@@ -1,5 +1,7 @@
 ---
 description: How to enable two-factor authentication on your emnify account
+last_update: 
+  date: 03-30-2023
 slug: /how-tos/two-factor-authentication
 ---
 

--- a/docs/how-tos/workspaces/create.md
+++ b/docs/how-tos/workspaces/create.md
@@ -1,6 +1,8 @@
 ---
 title: Create a new workspace
 description: How to submit a request for a new workspace
+last_update: 
+  date: 06-17-2023
 pagination_label: Create a new workspace
 pagination_next: how-tos/workspaces/link
 slug: /workspaces/create

--- a/docs/how-tos/workspaces/link.md
+++ b/docs/how-tos/workspaces/link.md
@@ -1,6 +1,8 @@
 ---
 title: Link an existing workspace
 description: If you already have two or more workspaces created
+last_update: 
+  date: 06-17-2023
 pagination_label: Link an existing workspace
 slug: /workspaces/link
 ---

--- a/docs/how-tos/workspaces/switch.md
+++ b/docs/how-tos/workspaces/switch.md
@@ -1,6 +1,8 @@
 ---
 title: Switch between workspaces
 description: Move between and manage multiple workspaces
+last_update: 
+  date: 06-17-2023
 pagination_label: Switch between workspaces
 slug: /workspaces/switch
 ---

--- a/docs/iot-supernetwork.md
+++ b/docs/iot-supernetwork.md
@@ -1,6 +1,8 @@
 ---
 description: What is the emnify IoT SuperNetwork and what sets it apart from traditional MNO and MVNOs
 pagination_next: quickstart/index
+last_update: 
+  date: 07-04-2023
 slug: /
 ---
 

--- a/docs/portal/dashboard.md
+++ b/docs/portal/dashboard.md
@@ -1,5 +1,7 @@
 ---
 description: The dashboard on the emnify Portal shows a summary of your usage for the current billing cycle
+last_update: 
+  date: 09-07-2023
 pagination_next: portal/sims-and-devices/sim-inventory
 slug: /portal
 ---

--- a/docs/portal/integrations/application-tokens.md
+++ b/docs/portal/integrations/application-tokens.md
@@ -1,5 +1,7 @@
 ---
 description: Add or view existing application tokens on the Integrations page of the emnify Portal
+last_update: 
+  date: 01-31-2023
 slug: /portal/application-tokens
 ---
 

--- a/docs/portal/integrations/no-code.md
+++ b/docs/portal/integrations/no-code.md
@@ -1,6 +1,8 @@
 ---
 description: Setup no-code workflows via Zapier, SMS, as well as event or application triggers in the emnify Portal
 pagination_next: portal/integrations/application-tokens
+last_update: 
+  date: 01-31-2023
 slug: /portal/no-code
 ---
 

--- a/docs/portal/organization/billing.md
+++ b/docs/portal/organization/billing.md
@@ -1,5 +1,7 @@
 ---
 description: View your organization's billing details in the emnify Portal
+last_update: 
+  date: 09-07-2023
 slug: /portal/org/billing
 ---
 

--- a/docs/portal/organization/data.md
+++ b/docs/portal/organization/data.md
@@ -1,5 +1,7 @@
 ---
 description: Keep your organization's information up to date in the emnify Portal
+last_update: 
+  date: 07-20-2023
 slug: /portal/org/data
 ---
 

--- a/docs/portal/organization/employees.md
+++ b/docs/portal/organization/employees.md
@@ -1,5 +1,7 @@
 ---
 description: Invite, assign a role, suspend, and delete employees within your organization on the emnify Portal
+last_update: 
+  date: 07-20-2023
 slug: /portal/org/employees
 ---
 

--- a/docs/portal/organization/settings.md
+++ b/docs/portal/organization/settings.md
@@ -1,5 +1,7 @@
 ---
 description: The starting point for managing your organization in the emnify Portal
+last_update: 
+  date: 07-20-2023
 pagination_next: portal/organization/data
 slug: /portal/org
 ---

--- a/docs/portal/organization/sso.md
+++ b/docs/portal/organization/sso.md
@@ -1,5 +1,7 @@
 ---
 description: Improve network security and simplify user administration
+last_update: 
+  date: 07-20-2023
 slug: /sso
 ---
 

--- a/docs/portal/organization/subscription.md
+++ b/docs/portal/organization/subscription.md
@@ -1,5 +1,7 @@
 ---
 description: View your current package or learn about others on the Subscription page in the emnify Portal
+last_update: 
+  date: 09-07-2023
 slug: /portal/org/subscription
 ---
 

--- a/docs/portal/organization/workspaces.md
+++ b/docs/portal/organization/workspaces.md
@@ -1,6 +1,8 @@
 ---
 title: Workspaces
 description: Organizations with complex business structures or diverse product lines can benefit from Workspaces in the emnify Portal
+last_update: 
+  date: 07-20-2023
 slug: /workspaces
 ---
 

--- a/docs/portal/reports.md
+++ b/docs/portal/reports.md
@@ -1,5 +1,7 @@
 ---
 description: Analyze data usage, events, and device location over time using the emnify Portal
+last_update: 
+  date: 09-07-2023
 slug: /portal/reports
 ---
 

--- a/docs/portal/roles.md
+++ b/docs/portal/roles.md
@@ -1,5 +1,7 @@
 ---
 description: Review the emnify account permissions for various roles
+last_update: 
+  date: 09-07-2023
 slug: /portal/roles
 ---
 

--- a/docs/portal/sims-and-devices/connected-devices.md
+++ b/docs/portal/sims-and-devices/connected-devices.md
@@ -1,5 +1,7 @@
 ---
 description: Learn how to manage your devices via the Connected Devices page in the emnify Portal
+last_update: 
+  date: 08-31-2023
 slug: /portal/connected-devices
 ---
 

--- a/docs/portal/sims-and-devices/device-policies.md
+++ b/docs/portal/sims-and-devices/device-policies.md
@@ -1,5 +1,7 @@
 ---
 description: Configure service and coverage policies for your devices on the emnify Portal
+last_update: 
+  date: 09-07-2023
 slug: /portal/device-policies
 ---
 

--- a/docs/portal/sims-and-devices/sim-inventory.md
+++ b/docs/portal/sims-and-devices/sim-inventory.md
@@ -1,5 +1,7 @@
 ---
 description: Learn how to manage your SIMs via the SIM Inventory in the emnify Portal
+last_update: 
+  date: 08-30-2023
 pagination_next: portal/sims-and-devices/connected-devices
 slug: /portal/sim-inventory
 ---

--- a/docs/portal/sims-and-devices/troubleshooting.md
+++ b/docs/portal/sims-and-devices/troubleshooting.md
@@ -1,5 +1,7 @@
 ---
 description: Tips and solutions for resolving why a device isn't performing as expected
+last_update: 
+  date: 07-20-2023
 slug: /portal/troubleshooting
 ---
 

--- a/docs/portal/sms.md
+++ b/docs/portal/sms.md
@@ -1,5 +1,7 @@
 ---
 description: Learn about the modes of SMS operation and use cases available on your emnify account for IoT devices
+last_update: 
+  date: 07-20-2023
 slug: /portal/sms
 ---
 

--- a/docs/portal/user-settings.md
+++ b/docs/portal/user-settings.md
@@ -1,5 +1,7 @@
 ---
 description: Managing your profile and preferences in the emnify Portal
+last_update: 
+  date: 07-20-2023
 slug: /portal/user-settings
 ---
 

--- a/docs/quickstart/apn-configuration/android.md
+++ b/docs/quickstart/apn-configuration/android.md
@@ -1,5 +1,7 @@
 ---
 description: Manually configure the APN for an Android device
+last_update: 
+  date: 01-07-2023
 slug: /apn-configuration/android
 ---
 

--- a/docs/quickstart/apn-configuration/cellular-modules.md
+++ b/docs/quickstart/apn-configuration/cellular-modules.md
@@ -1,5 +1,7 @@
 ---
 description: Configure Quectel, u-blox, and several other vendors
+last_update: 
+  date: 01-07-2023
 slug: /apn-configuration/cellular-modules
 ---
 

--- a/docs/quickstart/apn-configuration/gps-trackers.md
+++ b/docs/quickstart/apn-configuration/gps-trackers.md
@@ -1,5 +1,7 @@
 ---
 description: Configure the APN for the most common GPS vendors
+last_update: 
+  date: 01-25-2023
 slug: /apn-configuration/gps-trackers
 ---
 

--- a/docs/quickstart/apn-configuration/index.md
+++ b/docs/quickstart/apn-configuration/index.md
@@ -1,5 +1,7 @@
 ---
 description: Configure SIM-equipped devices with an Access Point Name (APN) via the emnify Portal
+last_update: 
+  date: 08-24-2023
 pagination_next: quickstart/apn-configuration/android
 slug: /apn-configuration
 ---

--- a/docs/quickstart/apn-configuration/industrial-routers.md
+++ b/docs/quickstart/apn-configuration/industrial-routers.md
@@ -1,5 +1,7 @@
 ---
 description: Connect to routers to configure the APN
+last_update: 
+  date: 02-21-2023
 slug: /apn-configuration/industrial-routers
 ---
 

--- a/docs/quickstart/apn-configuration/ios.md
+++ b/docs/quickstart/apn-configuration/ios.md
@@ -1,5 +1,7 @@
 ---
 description: Manually configure the APN for an iOS device
+last_update: 
+  date: 01-07-2023
 slug: /apn-configuration/ios
 ---
 

--- a/docs/quickstart/create-device.md
+++ b/docs/quickstart/create-device.md
@@ -1,5 +1,7 @@
 ---
 description: Define the device to be used with the SIM
+last_update: 
+  date: 08-24-2023
 slug: /quickstart/create-device
 ---
 

--- a/docs/quickstart/index.md
+++ b/docs/quickstart/index.md
@@ -1,5 +1,7 @@
 ---
 description: Start developing your IoT solutions with emnify
+last_update: 
+  date: 09-07-2023
 pagination_label: Getting started with emnify
 pagination_next: quickstart/order-sims
 slug: /quickstart

--- a/docs/quickstart/order-sims.md
+++ b/docs/quickstart/order-sims.md
@@ -1,5 +1,7 @@
 ---
 description: Step-by-step guide to order emnify SIMs from the SIM Shop
+last_update: 
+  date: 05-12-2023
 slug: /quickstart/order-sims
 ---
 

--- a/docs/quickstart/register-sims.md
+++ b/docs/quickstart/register-sims.md
@@ -1,5 +1,7 @@
 ---
 description: Use your emnify account to register your SIMs
+last_update: 
+  date: 08-30-2023
 slug: /quickstart/register-sims
 ---
 

--- a/docs/quickstart/troubleshooting.md
+++ b/docs/quickstart/troubleshooting.md
@@ -1,5 +1,7 @@
 ---
 description: Tips and solutions for resolving common issues when setting up your emnify account
+last_update: 
+  date: 08-24-2023
 slug: /quickstart/troubleshooting
 ---
 

--- a/docs/rest/authentication.md
+++ b/docs/rest/authentication.md
@@ -1,6 +1,8 @@
 ---
 description: Retrieve your authentication token 
 displayed_sidebar: devResourcesSidebar
+last_update: 
+  date: 11-04-2021
 ---
 
 # Authentication

--- a/docs/rest/index.md
+++ b/docs/rest/index.md
@@ -1,6 +1,8 @@
 ---
 description: Introduce the OpenAPI structure and code samples
 displayed_sidebar: devResourcesSidebar
+last_update: 
+  date: 11-02-2021
 pagination_next: rest/authentication
 slug: /rest
 ---

--- a/docs/rest/sms-operations.md
+++ b/docs/rest/sms-operations.md
@@ -1,6 +1,8 @@
 ---
 description: Perform SMS related operations with the API 
 displayed_sidebar: devResourcesSidebar
+last_update: 
+  date: 11-04-2021
 ---
 
 # Send and receive SMS

--- a/docs/sdks/concepts.md
+++ b/docs/sdks/concepts.md
@@ -1,5 +1,7 @@
 ---
 description: Must-knows for working with the emnify SDKs
+last_update: 
+  date: 09-07-2023
 slug: /sdks/concepts
 ---
 

--- a/docs/sdks/index.md
+++ b/docs/sdks/index.md
@@ -1,4 +1,6 @@
 ---
+last_update: 
+  date: 04-26-2023
 pagination_prev: graphql/preview
 pagination_next: sdks/concepts
 slug: /sdks

--- a/docs/sdks/java/examples.md
+++ b/docs/sdks/java/examples.md
@@ -1,5 +1,7 @@
 ---
 description: Code samples showing how to use the emnify Java SDK
+last_update: 
+  date: 08-20-2021
 slug: /sdks/java/examples
 ---
 

--- a/docs/sdks/java/quickstart.md
+++ b/docs/sdks/java/quickstart.md
@@ -1,5 +1,7 @@
 ---
 description: Step-by-step guide for installing and using the emnify Java SDK
+last_update: 
+  date: 08-20-2021
 pagination_prev: sdks/python/quickstart
 pagination_next: sdks/java/examples
 slug: /sdks/java/quickstart

--- a/docs/sdks/python/examples.md
+++ b/docs/sdks/python/examples.md
@@ -1,5 +1,7 @@
 ---
 description: Code samples showing how to use the emnify python SDK
+last_update: 
+  date: 09-06-2023
 slug: /sdks/python/examples
 ---
 

--- a/docs/sdks/python/quickstart.md
+++ b/docs/sdks/python/quickstart.md
@@ -1,5 +1,7 @@
 ---
 description: Step-by-step guide for installing and using the emnify Python SDK
+last_update: 
+  date: 09-07-2022
 pagination_next: sdks/python/examples
 slug: /sdks/python/quickstart
 ---

--- a/docs/sdks/support.md
+++ b/docs/sdks/support.md
@@ -1,5 +1,7 @@
 ---
 description: Get support and give us feedback on the emnify SDKs
+last_update: 
+  date: 04-26-2023
 slug: /sdks/support
 ---
 

--- a/docs/services/connectivity/global-iot-sim.md
+++ b/docs/services/connectivity/global-iot-sim.md
@@ -1,5 +1,7 @@
 ---
 description: Overview of the available emnify SIMs, including form factors, quality grades, multi-IMSI, eSIM, and eUICC
+last_update: 
+  date: 08-10-2023
 pagination_next: services/connectivity/sim-lifecycle-management
 slug: /services/global-iot-sim
 ---

--- a/docs/services/connectivity/sim-lifecycle-management.md
+++ b/docs/services/connectivity/sim-lifecycle-management.md
@@ -1,5 +1,7 @@
 ---
 description: Configure SIM state to minimize costs
+last_update: 
+  date: 08-31-2023
 slug: /services/sim-lifecycle-management
 ---
 

--- a/docs/services/connectivity/sms.md
+++ b/docs/services/connectivity/sms.md
@@ -1,5 +1,7 @@
 ---
 description: Send/receive SMS via the emnify Portal, SMS APIs, or Zapier
+last_update: 
+  date: 01-06-2023
 slug: /services/sms
 ---
 

--- a/docs/services/network/cloud-connect.md
+++ b/docs/services/network/cloud-connect.md
@@ -1,5 +1,7 @@
 ---
 description: AWS Intra-Cloud Connect, IPsec
+last_update: 
+  date: 11-04-2021
 slug: /services/cloud-connect
 ---
 

--- a/docs/services/network/global-iot-network.md
+++ b/docs/services/network/global-iot-network.md
@@ -1,5 +1,7 @@
 ---
 description: Network aggregation supporting all radio types
+last_update: 
+  date: 08-24-2021
 pagination_next: services/network/iot-cloud-communication-platform
 slug: /services/global-iot-network
 ---

--- a/docs/services/network/iot-cloud-communication-platform.md
+++ b/docs/services/network/iot-cloud-communication-platform.md
@@ -1,5 +1,7 @@
 ---
 description: Distributed data plane, traditional operators vs emnify, regional breakout
+last_update: 
+  date: 11-09-2021
 slug: /services/iot-cloud-communication-platform
 ---
 

--- a/docs/services/network/openvpn.md
+++ b/docs/services/network/openvpn.md
@@ -1,5 +1,7 @@
 ---
 description: Overview and setup
+last_update: 
+  date: 11-04-2021
 slug: /services/openvpn
 ---
 

--- a/docs/services/platform/data-streamer/connection-types.md
+++ b/docs/services/platform/data-streamer/connection-types.md
@@ -1,5 +1,7 @@
 ---
 description: Integrate real-time data streams of your devices and SIMs with the emnify multicloud Data Streamer
+last_update: 
+  date: 12-31-2022
 slug: /multicloud-data-streamer/connection-types
 ---
 

--- a/docs/services/platform/data-streamer/data-streams.md
+++ b/docs/services/platform/data-streamer/data-streams.md
@@ -1,5 +1,7 @@
 ---
 description: Set up, filter, pause, or delete data streams with the emnify multicloud Data Streamer
+last_update: 
+  date: 12-31-2022
 slug: /multicloud-data-streamer/manage-data-streams
 ---
 

--- a/docs/services/platform/data-streamer/index.md
+++ b/docs/services/platform/data-streamer/index.md
@@ -1,5 +1,7 @@
 ---
 description: Benefits of emnify's multicloud Data Streamer and how to get started
+last_update: 
+  date: 12-31-2022
 pagination_next: services/platform/data-streamer/connection-types
 slug: /multicloud-data-streamer
 ---

--- a/docs/services/platform/data-streamer/integrations.md
+++ b/docs/services/platform/data-streamer/integrations.md
@@ -1,5 +1,7 @@
 ---
 description: List of available third-party integrations for the emnify multicloud Data streamer and links to step-by-step implementation guides
+last_update: 
+  date: 12-31-2022
 slug: /multicloud-data-streamer/integrations
 ---
 

--- a/docs/services/platform/data-streamer/stream-types.md
+++ b/docs/services/platform/data-streamer/stream-types.md
@@ -1,5 +1,7 @@
 ---
 description: Configure the type of content delivered by the data stream
+last_update: 
+  date: 12-31-2022
 slug: /multicloud-data-streamer/stream-types
 ---
 

--- a/docs/services/platform/data-streamer/usage.md
+++ b/docs/services/platform/data-streamer/usage.md
@@ -1,5 +1,7 @@
 ---
 description: Manage data streams with the emnify Portal or REST API
+last_update: 
+  date: 12-31-2022
 slug: /multicloud-data-streamer/usage
 ---
 

--- a/docs/services/platform/events/event-types.md
+++ b/docs/services/platform/events/event-types.md
@@ -1,5 +1,7 @@
 ---
 description: List of all available event types
+last_update: 
+  date: 01-10-2023
 slug: /system-events/event-types
 ---
 

--- a/docs/services/platform/events/index.md
+++ b/docs/services/platform/events/index.md
@@ -1,5 +1,7 @@
 ---
 description: Learn the basics and structure of emnify system events
+last_update: 
+  date: 01-03-2023
 pagination_prev: services/platform/data-streamer/index
 pagination_next: services/platform/events/event-types
 slug: /system-events

--- a/docs/services/platform/events/usage.md
+++ b/docs/services/platform/events/usage.md
@@ -1,5 +1,7 @@
 ---
 description: Manage events with emnify's Data Streamer, REST API, or Portal
+last_update: 
+  date: 01-11-2023
 slug: /system-events/usage
 ---
 

--- a/docs/services/platform/integration-guides/index.md
+++ b/docs/services/platform/integration-guides/index.md
@@ -1,5 +1,7 @@
 ---
 pagination_next: services/platform/data-streamer/index
+last_update: 
+  date: 02-15-2023
 slug: /integration-guides
 ---
 

--- a/docs/services/platform/security.md
+++ b/docs/services/platform/security.md
@@ -1,5 +1,7 @@
 ---
 description: SASE approach, DNS, IMEI lock
+last_update: 
+  date: 01-17-2023
 pagination_prev: services/platform/events/index
 slug: /services/security
 ---

--- a/docs/support.md
+++ b/docs/support.md
@@ -1,5 +1,7 @@
 ---
 description: Ensuring your success with emnify products and services
+last_update: 
+  date: 04-13-2023
 ---
 
 # Support


### PR DESCRIPTION
<!--
  Thanks for making a pull request!
  Please make sure your title is as descriptive as possible. It's important for commit hisotry as we squash on merge and use the pull request title as the commit message.

  Have any questions?
  Feel free to ask in this PR or you can also send us an email: docs@emnify.com
-->

### Description

The current "Last updated on" date shown on the content pages is misleading. Any time the file is updated for any reason, it automatically changes this date to match that commit.

This PR proposes that we manually update this date when there is an actual change or update to the content itself. That way, everyone involved (internal stakeholders and customers alike) have a more accurate picture of how up-to-date they should expect these docs to be. It also enables internal maintainers to better track and update outdated content 🗑️ 🔥 

> **Note**
> Each page has been checked and the date has been determined based on the last major content change. For pages pre-date the initial migration to Docusaurus in January 2023, I used the archived https://github.com/emnify/documentation has a reference.

<!-- Write a brief description of the changes introduced by this PR -->

