### PR TITLE
Move 'Developer resources' section back under main sidebar

### DIFF
--- a/docs/graphql/graphiql-ide.md
+++ b/docs/graphql/graphiql-ide.md
@@ -1,5 +1,4 @@
 ---
-displayed_sidebar: devResourcesSidebar
 last_update: 
   date: 08-30-2023
 slug: /graphql/graphiql-ide

--- a/docs/graphql/preview.md
+++ b/docs/graphql/preview.md
@@ -1,6 +1,5 @@
 ---
 title: Preview the GraphQL API
-displayed_sidebar: devResourcesSidebar
 last_update: 
   date: 03-17-2023
 pagination_label: Preview the GraphQL API

--- a/docs/rest/authentication.md
+++ b/docs/rest/authentication.md
@@ -1,6 +1,5 @@
 ---
 description: Retrieve your authentication token 
-displayed_sidebar: devResourcesSidebar
 last_update: 
   date: 11-04-2021
 ---

--- a/docs/rest/index.md
+++ b/docs/rest/index.md
@@ -1,6 +1,5 @@
 ---
 description: Introduce the OpenAPI structure and code samples
-displayed_sidebar: devResourcesSidebar
 last_update: 
   date: 11-02-2021
 pagination_next: rest/authentication

--- a/docs/rest/sms-operations.md
+++ b/docs/rest/sms-operations.md
@@ -1,6 +1,5 @@
 ---
 description: Perform SMS related operations with the API 
-displayed_sidebar: devResourcesSidebar
 last_update: 
   date: 11-04-2021
 ---

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -119,20 +119,6 @@ const config = {
           href: "/",
           src: "img/logo-word-blue-295x80.png",
         },
-        items: [
-          {
-            type: "docSidebar",
-            position: "left",
-            sidebarId: "mainDocsSidebar",
-            label: "Home",
-          },
-          {
-            type: "docSidebar",
-            position: "left",
-            sidebarId: "devResourcesSidebar",
-            label: "Developer Resources",
-          },
-        ],
       },
       docs: {
         sidebar: {

--- a/sidebars.js
+++ b/sidebars.js
@@ -203,6 +203,109 @@ const sidebars = {
     },
     {
       type: "category",
+      label: "Developer resources",
+      items: [
+        {
+          type: "category",
+          label: "REST API",
+          link: {
+            type: "doc",
+            id: "rest/index",
+          },
+          items: [
+            {
+              type: "doc",
+              label: "Overview",
+              id: "rest/index",
+            },
+            "rest/authentication",
+            "rest/sms-operations",
+            {
+              type: "link",
+              label: "API reference",
+              href: "https://cdn.emnify.net/api/doc/index.html",
+            },
+          ],
+        },
+        {
+          type: "category",
+          label: "GraphQL API",
+          link: {
+            type: "doc",
+            id: "graphql/preview",
+          },
+          items: [
+            {
+              type: "doc",
+              label: "Preview the GraphQL API",
+              id: "graphql/preview",
+            },
+            "graphql/graphiql-ide",
+          ],
+        },
+        {
+          type: "category",
+          label: "SDKs",
+          link: {
+            type: "doc",
+            id: "sdks/index",
+          },
+          items: [
+            {
+              type: "doc",
+              label: "Overview",
+              id: "sdks/index",
+            },
+            "sdks/concepts",
+            {
+              type: "category",
+              label: "Python",
+              link: {
+                type: "doc",
+                id: "sdks/python/quickstart",
+              },
+              items: [
+                {
+                  type: "doc",
+                  label: "Getting started",
+                  id: "sdks/python/quickstart",
+                },
+                "sdks/python/examples",
+                {
+                  type: "link",
+                  label: "API Reference",
+                  href: "https://emnify.github.io/emnify-sdk-python/autoapi/index.html",
+                },
+              ],
+            },
+            {
+              type: "category",
+              label: "Java",
+              link: {
+                type: "doc",
+                id: "sdks/java/quickstart",
+              },
+              items: [
+                {
+                  type: "doc",
+                  label: "Getting started",
+                  id: "sdks/java/quickstart",
+                },
+                "sdks/java/examples",
+                {
+                  type: "link",
+                  label: "API Reference",
+                  href: "https://emnify.github.io/emnify-sdk-java/",
+                },
+              ],
+            },
+            "sdks/support",
+          ],
+        },
+      ],
+    },
+    {
+      type: "category",
       label: "How-to guides",
       link: {
         type: "doc",
@@ -271,105 +374,6 @@ const sidebars = {
     },
     "glossary",
     "support",
-  ],
-  devResourcesSidebar: [
-    {
-      type: "category",
-      label: "REST API",
-      link: {
-        type: "doc",
-        id: "rest/index",
-      },
-      items: [
-        {
-          type: "doc",
-          label: "Overview",
-          id: "rest/index",
-        },
-        "rest/authentication",
-        "rest/sms-operations",
-        {
-          type: "link",
-          label: "API reference",
-          href: "https://cdn.emnify.net/api/doc/index.html",
-        },
-      ],
-    },
-    {
-      type: "category",
-      label: "GraphQL API",
-      link: {
-        type: "doc",
-        id: "graphql/preview",
-      },
-      items: [
-        {
-          type: "doc",
-          label: "Preview the GraphQL API",
-          id: "graphql/preview",
-        },
-        "graphql/graphiql-ide",
-      ],
-    },
-    {
-      type: "category",
-      label: "SDKs",
-      link: {
-        type: "doc",
-        id: "sdks/index",
-      },
-      items: [
-        {
-          type: "doc",
-          label: "Overview",
-          id: "sdks/index",
-        },
-        "sdks/concepts",
-        {
-          type: "category",
-          label: "Python",
-          link: {
-            type: "doc",
-            id: "sdks/python/quickstart",
-          },
-          items: [
-            {
-              type: "doc",
-              label: "Getting started",
-              id: "sdks/python/quickstart",
-            },
-            "sdks/python/examples",
-            {
-              type: "link",
-              label: "API Reference",
-              href: "https://emnify.github.io/emnify-sdk-python/autoapi/index.html",
-            },
-          ],
-        },
-        {
-          type: "category",
-          label: "Java",
-          link: {
-            type: "doc",
-            id: "sdks/java/quickstart",
-          },
-          items: [
-            {
-              type: "doc",
-              label: "Getting started",
-              id: "sdks/java/quickstart",
-            },
-            "sdks/java/examples",
-            {
-              type: "link",
-              label: "API Reference",
-              href: "https://emnify.github.io/emnify-sdk-java/",
-            },
-          ],
-        },
-        "sdks/support",
-      ],
-    },
   ],
 };
 


### PR DESCRIPTION
### Description

Implemented as a suggestion from Product Design when they reviewed the site with the new tokens, but because this change isn't blocked by the token implementation.

> **Note**
> Only the top-level and sidebar nav changes, not the actual content or pages. 

<img width="634" alt="Screenshot 2023-09-14 at 14 41 38" src="https://github.com/emnify/product-docs/assets/26869552/fb476de6-55bc-47b8-ba2f-3571ee616b14">

<!-- Write a brief description of the changes introduced by this PR -->

### Additional Context

Internal 🎫 [DOCS-140](https://emnify.atlassian.net/browse/DOCS-140)

<!--
    Anything else that will help us better understand, for example:
      * Link(s) to the relevant issue or ticket
      * Screenshots
      * Reference resources
-->
