### PR TITLE
Incorporate subscription FAQ content into the docs

### DIFF
--- a/docs/how-tos/data-allowances.md
+++ b/docs/how-tos/data-allowances.md
@@ -7,7 +7,7 @@ slug: /how-tos/data-allowances
 
 # Change the assigned data allowance
 
-Data allowances are managed within [coverage policies](/portal/device-policies#coverage-policies).
+Data plans and the associated allowances are managed within [coverage policies](/portal/device-policies#coverage-policies).
 
 With the **Pro Package**, you can manage as many data plans as you need.
 Those with a **Plus Package** can manage up to 4 data plans.
@@ -98,3 +98,7 @@ To change a coverage policy's data plan in the Portal, follow these steps:
 1. Go to [**Coverage Policies**](https://portal.emnify.com/device-policies).
 1. Find the coverage policy you want to update and click **Details**.
 1. Use the **Data Plan** dropdown to select a new data plan or use the toggles to adjust the **Coverage areas**.
+
+:::caution
+When a data plan includes active SIMs, it's added to your bill at the end of the month.
+:::

--- a/docs/portal/organization/subscription.md
+++ b/docs/portal/organization/subscription.md
@@ -89,7 +89,7 @@ When finished, select **Save**.
 
 :::info
 Your new package is charged immediately in the next billing cycle.
-You'll be charged the total package price regardless of when you upgrade, as emnify doesn't offer partials.
+You'll be charged the total package price regardless of when you upgrade, as emnify doesn't prorate.
 :::
 
 ## Cancel your package

--- a/docs/portal/organization/subscription.md
+++ b/docs/portal/organization/subscription.md
@@ -86,3 +86,13 @@ On the **Data plan upgrade** page, you'll have an opportunity to confirm the fol
     - PayPal
 
 When finished, select **Save**.
+
+:::info
+Your new package is charged immediately in the next billing cycle.
+You'll be charged the total package price regardless of when you upgrade, as emnify doesn't offer partials.
+:::
+
+## Cancel your package
+
+You can cancel your package monthly, unless your contract specifies otherwise.
+To cancel your current package, contact the [emnify support team](/support).


### PR DESCRIPTION
<!--
  Thanks for making a pull request!
  Please make sure your title is as descriptive as possible. It's important for commit hisotry as we squash on merge and use the pull request title as the commit message.

  Have any questions?
  Feel free to ask in this PR or you can also send us an email: docs@emnify.com
-->

### Description

For the new subscription page FAQs, the Growth squad wants the option to use the prepared content _or_ only link to the documentation. This requires those answers being incorporated into the docs, so that's what this PR does.

> **Note**
> The Factory Test Mode answers are handled in #187 

<!-- Write a brief description of the changes introduced by this PR -->

### Tips for reviewers

Slugs with changes:
- `/how-tos/data-allowances`
- `/portal/org/subscription`

### Additional Context

* [Current draft of FAQ content](https://emnify.atlassian.net/browse/PGR-370?focusedCommentId=24029)
* Internal 🎫 [PGR-370](https://emnify.atlassian.net/browse/PGR-370)

<!--
    Anything else that will help us better understand, for example:
      * Link(s) to the relevant issue or ticket
      * Screenshots
      * Reference resources
-->


[PGR-370]: https://emnify.atlassian.net/browse/PGR-370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ