### PR TITLE
Specify the Vale CLI version to use in workflows

### DIFF
--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: errata-ai/vale-action@reviewdog
         with:
+          version: 2.30.0
           fail_on_error: true
           vale_flags: "--minAlertLevel=error"
         env:


### PR DESCRIPTION
<!--
  Thanks for making a pull request!
  Please make sure your title is as descriptive as possible. It's important for commit hisotry as we squash on merge and use the pull request title as the commit message.

  Have any questions?
  Feel free to ask in this PR or you can also send us an email: docs@emnify.com
-->

### Description

Yesterday our Vale workflow runs starting unexpectedly failing, despite no changes to the config or setup. After reading through https://github.com/errata-ai/vale-action/issues/113, I've identified the issue as our setup not being compatible with the latest Vale CLI version (v3.0.0). As a temporary fix, I've specified the CLI version in the workflow and I'll create a follow-up task to upgrade our config to be compatible with the latest release. 

<!-- Write a brief description of the changes introduced by this PR -->

### Additional Context

Internal 🎟️ [DOCS-317](https://emnify.atlassian.net/browse/DOCS-317) 🪲 

<!--
    Anything else that will help us better understand, for example:
      * Link(s) to the relevant issue or ticket
      * Screenshots
      * Reference resources
-->


[DOCS-317]: https://emnify.atlassian.net/browse/DOCS-317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ