### PR TITLE
Add session_id field to Data Streamer usage object example responses

### DIFF
--- a/docs/services/platform/data-streamer/stream-types.md
+++ b/docs/services/platform/data-streamer/stream-types.md
@@ -128,7 +128,8 @@ Data usage records are created:
             "symbol": "€"
         },
         "end_timestamp": "2022-04-26T12:02:43Z",
-        "imsi_id": 9624042
+        "imsi_id": 9624042,
+        "session_id": "722aeb56-c4de-4753-ac23-4f99c1980c5e"
     }
 ]
 ```
@@ -216,7 +217,8 @@ Usage records for SMS are created when an SMS is successfully delivered either:
             "symbol": "€"
         },
         "end_timestamp": "2022-04-26T13:13:56Z",
-        "imsi_id": 9624042
+        "imsi_id": 9624042,
+        "session_id": "beafcbbf-48b7-49c5-b493-fce36bad466a"
     }
 ]
 ```


### PR DESCRIPTION
<!--
  Thanks for making a pull request!
  Please make sure your title is as descriptive as possible. It's important for commit hisotry as we squash on merge and use the pull request title as the commit message.

  Have any questions?
  Feel free to ask in this PR or you can also send us an email: docs@emnify.com
-->

### Description

Adds `session_id` field with an example UUID value to the Data Streamer stream type examples from https://docs.emnify.com/multicloud-data-streamer/stream-types

<!-- Write a brief description of the changes introduced by this PR -->

### Additional Context

Internal 🎫 [CHL-1007](https://emnify.atlassian.net/browse/CHL-1007)

<!--
    Anything else that will help us better understand, for example:
      * Link(s) to the relevant issue or ticket
      * Screenshots
      * Reference resources
-->


[CHL-1007]: https://emnify.atlassian.net/browse/CHL-1007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ