### PR TITLE
Update Data Streamer usage object and Events details object to reflect current functionality

### DIFF
--- a/docs/services/platform/data-streamer/stream-types.md
+++ b/docs/services/platform/data-streamer/stream-types.md
@@ -1,7 +1,7 @@
 ---
 description: Configure the type of content delivered by the data stream
 last_update: 
-  date: 12-31-2022
+  date: 02-15-2024
 slug: /multicloud-data-streamer/stream-types
 ---
 
@@ -64,8 +64,8 @@ Data usage records are created:
 ```json
 [
     {
-        "cost": 0.00439866,
-        "id": 393533342974012,
+        "cost": 0.00188512,
+        "id": 333333333333333,
         "operator": { // network
             "id": 5,
             "name": "Telefonica O2",
@@ -77,15 +77,15 @@ Data usage records are created:
             }
         },
         "organisation": {
-            "id": 11060,
-            "name": "emnify LTEM Demo"
+            "id": 12345,
+            "name": "Example Organization"
         },
         "tariff": { // data plan
-            "id": 557,
-            "name": "Regional Pro EUR",
+            "id": 1,
+            "name": "Internal Test Data Plan",
             "ratezone": { // coverage area
-                "id": 3398,
-                "name": "Europe Basic"
+                "id": 2,
+                "name": "Area 2"
             }
         },
         "traffic_type": { // usage type
@@ -93,21 +93,12 @@ Data usage records are created:
             "description": "Data"
         },
         "endpoint": { // device
-            "id": 10830095,
-            "name": "Wallbox 232",
-            "ip_address": "10.196.67.7",
+            "id": 123456789,
+            "name": "Example Device",
+            "ip_address": "192.0.2.7",
             "tags": "V1",
             "imei": "8677300511111142",
-            "balance": {
-                "amount": -0.684147,
-                "last_updated": "2022-04-26T12:02:21Z",
-                "expiry_date": "2022-04-06T08:00:00Z",
-                "currency": {
-                    "id": 1,
-                    "code": "EUR",
-                    "symbol": "€"
-                }
-            }
+            "balance": null
         },
         "imsi": "295050901064821",
         "volume": {
@@ -118,7 +109,7 @@ Data usage records are created:
         "start_timestamp": "2022-04-26T11:53:43Z",
         "sim": {
             "id": 3324192,
-            "iccid": "8988303000005555555",
+            "iccid": "89883030000080139311",
             "msisdn": "423663920123456",
             "production_date": "2020-09-09T06:42:59Z"
         },
@@ -127,7 +118,7 @@ Data usage records are created:
             "code": "EUR",
             "symbol": "€"
         },
-        "end_timestamp": "2022-04-26T12:02:43Z",
+        "end_timestamp": "2024-02-15T14:56:15.260Z",
         "imsi_id": 9624042,
         "session_id": "722aeb56-c4de-4753-ac23-4f99c1980c5e"
     }
@@ -154,7 +145,7 @@ Usage records for SMS are created when an SMS is successfully delivered either:
 [
     {
         "cost": 0.07,
-        "id": 393603365044284,
+        "id": 333333333333333,
         "operator": { // network
             "id": 5,
             "name": "Telefonica O2",
@@ -166,8 +157,8 @@ Usage records for SMS are created when an SMS is successfully delivered either:
             }
         },
         "organisation": {
-            "id": 11060,
-            "name": "emnify LTEM Demo"
+            "id": 12345,
+            "name": "Example Organization"
         },
         "tariff": { // data plan
             "id": 1,
@@ -182,21 +173,12 @@ Usage records for SMS are created when an SMS is successfully delivered either:
             "description": "SMS"
         },
         "endpoint": { // device
-            "id": 10830095,
-            "name": "Wallbox 232",
-            "ip_address": "10.196.67.7",
+            "id": 123456789,
+            "name": "Example Device",
+            "ip_address": "192.0.2.88",
             "tags": "V1",
             "imei": "8677300511111142",
-            "balance": {
-                "amount": -0.754147,
-                "last_updated": "2022-04-26T13:13:56Z",
-                "expiry_date": "2022-04-06T08:00:00Z",
-                "currency": {
-                    "id": 1,
-                    "code": "EUR",
-                    "symbol": "€"
-                }
-            }
+            "balance": null
         },
         "imsi": "901430111111111",
         "volume": {
@@ -206,8 +188,8 @@ Usage records for SMS are created when an SMS is successfully delivered either:
         },
         "start_timestamp": "2022-04-26T13:13:56Z",
         "sim": {
-            "id": 3324192,
-            "iccid": "8988303000005555555",
+            "id": 123456,
+            "iccid": "89883030000080139312",
             "msisdn": "423663920123456",
             "production_date": "2020-09-09T06:42:59Z"
         },
@@ -216,7 +198,7 @@ Usage records for SMS are created when an SMS is successfully delivered either:
             "code": "EUR",
             "symbol": "€"
         },
-        "end_timestamp": "2022-04-26T13:13:56Z",
+        "end_timestamp": "2024-02-15T14:56:15.260Z",
         "imsi_id": 9624042,
         "session_id": "beafcbbf-48b7-49c5-b493-fce36bad466a"
     }

--- a/docs/services/platform/events/event-types.md
+++ b/docs/services/platform/events/event-types.md
@@ -1,7 +1,7 @@
 ---
 description: List of all available event types
 last_update: 
-  date: 09-08-2023
+  date: 02-15-2024
 slug: /system-events/event-types
 ---
 
@@ -470,45 +470,45 @@ This device appears as **Online** in the [emnify Portal](/system-events/usage#em
   },
   "detail": {
     "country": {
-      "country_code": "49",
       "mcc": "262",
       "name": "Germany",
+      "country_code": "49",
       "iso_code": "de",
       "id": 74
     },
-    "name": "Vodafone",
+    "id": 3,
+    "session_id": "d12c574f-e219-45a4-8836-d17a50f66fb1",
     "pdp_context": {
-      "tariff_profile_id": "395978", // coverage policy
-      "tx_teid_control_plane": 570842943,
       "breakout_ip": "97.106.216.29",
-      "tariff_id": "555", // data plan
       "rac": null,
-      "ratezone_id": "8178", // coverage area
-      "ci": 5174,
-      "imeisv": "6887426203768011",
-      "lac": 921,
-      "sac": null,
-      "gtp_version": 1,
-      "rat_type": 2,
-      "mcc": "262",
-      "tx_teid_data_plane": 557727595,
-      "ue_ip_address": "101.124.109.214",
-      "ggsn_data_plane_ip_address": "150.85.110.76",
-      "tunnel_created": "2021-10-27T08:38:02",
-      "pdp_context_id": 51755555,
-      "ggsn_control_plane_ip_address": "60.195.159.61",
       "sgsn_control_plane_ip_address": "117.72.59.30",
-      "nsapi": 5,
+      "rat_type": 2,
+      "tx_teid_data_plane": 557727595,
       "region": "eu-west-1",
       "apn": "em",
-      "mnc": "02",
+      "tx_teid_control_plane": 570842943,
+      "tunnel_created": "2021-10-27T08:38:02",
+      "ggsn_data_plane_ip_address": "150.85.110.76",
       "sgsn_data_plane_ip_address": "223.253.0.120",
-      "operator_id": "3",
-      "imsi": "82186563190127",
       "rx_teid": 96601675,
-      "session_id": "d12c574f-e219-45a4-8836-d17a50f66fb1"
+      "ci": 5174,
+      "imsi": "82186563190127",
+      "lac": 921,
+      "mcc": "262",
+      "sac": null,
+      "ggsn_control_plane_ip_address": "60.195.159.61",
+      "mnc": "02",
+      "nsapi": 5,
+      "ue_ip_address": "101.124.109.214",
+      "imeisv": "6887426203768011",
+      "pdp_context_id": 51755555,
+      "gtp_version": 1,
+      "operator_id": "3",
+      "tariff_profile_id": "395978", // coverage policy
+      "ratezone_id": "8178", // coverage area
+      "tariff_id": "555" // data plan
     },
-    "id": 3
+    "name": "Vodafone"
   }
 }
 ```
@@ -760,40 +760,40 @@ The event details also show the data transmitted, and the device appears as **At
             "iso_code": "de",
             "id": 82
         },
-        "name": "Vodafone",
         "volume": {
             "total": 0.641984,
             "rx": 0.418811,
             "tx": 0.223173
         },
+        "id": 3,
+        "session_id": "2a4ff039-fbb9-4eaa-b74c-2f0eaafaf624",
         "pdp_context": {
-            "tx_teid_control_plane": 397629956,
             "breakout_ip": null,
             "rac": null,
-            "ci": 6471,
-            "imeisv": "4555797980633712",
-            "lac": 767,
-            "sac": null,
-            "gtp_version": 1,
-            "rat_type": 2,
-            "mcc": "262",
-            "tx_teid_data_plane": 966839357,
-            "ue_ip_address": "66.185.97.229",
-            "ggsn_data_plane_ip_address": "225.129.61.136",
-            "tunnel_created": "2021-10-27T08:38:02",
-            "pdp_context_id": 79790039,
-            "ggsn_control_plane_ip_address": "67.185.18.116",
             "sgsn_control_plane_ip_address": "234.39.123.228",
-            "nsapi": 5,
+            "rat_type": 2,
+            "tx_teid_data_plane": 966839357,
             "region": "eu-west-1",
             "apn": null,
-            "mnc": "02",
+            "tx_teid_control_plane": 397629956,
+            "tunnel_created": "2021-10-27T08:38:02",
+            "ggsn_data_plane_ip_address": "225.129.61.136",
             "sgsn_data_plane_ip_address": "173.69.12.45",
-            "imsi": "369573775632443",
             "rx_teid": 18195957,
-            "session_id": "2a4ff039-fbb9-4eaa-b74c-2f0eaafaf624"
+            "ci": 6471,
+            "imsi": "369573775632443",
+            "lac": 767,
+            "mcc": "262",
+            "sac": null,
+            "ggsn_control_plane_ip_address": "67.185.18.116",
+            "mnc": "02",
+            "nsapi": 5,
+            "ue_ip_address": "66.185.97.229",
+            "imeisv": "4555797980633712",
+            "pdp_context_id": 79790039,
+            "gtp_version": 1
         },
-        "id": 3
+        "name": "Vodafone"
     }
 }
 ```

--- a/docs/services/platform/events/event-types.md
+++ b/docs/services/platform/events/event-types.md
@@ -505,7 +505,8 @@ This device appears as **Online** in the [emnify Portal](/system-events/usage#em
       "sgsn_data_plane_ip_address": "223.253.0.120",
       "operator_id": "3",
       "imsi": "82186563190127",
-      "rx_teid": 96601675
+      "rx_teid": 96601675,
+      "session_id": "d12c574f-e219-45a4-8836-d17a50f66fb1"
     },
     "id": 3
   }
@@ -789,7 +790,8 @@ The event details also show the data transmitted, and the device appears as **At
             "mnc": "02",
             "sgsn_data_plane_ip_address": "173.69.12.45",
             "imsi": "369573775632443",
-            "rx_teid": 18195957
+            "rx_teid": 18195957,
+            "session_id": "2a4ff039-fbb9-4eaa-b74c-2f0eaafaf624"
         },
         "id": 3
     }


### PR DESCRIPTION
<!--
  Thanks for making a pull request!
  Please make sure your title is as descriptive as possible. It's important for commit hisotry as we squash on merge and use the pull request title as the commit message.

  Have any questions?
  Feel free to ask in this PR or you can also send us an email: docs@emnify.com
-->

### Description

Follow up from #282 

- Adds `session_id` to Details object in example event responses
- Updates Data Streamer usage object response example

<!-- Write a brief description of the changes introduced by this PR -->

### Additional Context

Internal 🎫 [CHL-1013](https://emnify.atlassian.net/browse/CHL-1013)

<!--
    Anything else that will help us better understand, for example:
      * Link(s) to the relevant issue or ticket
      * Screenshots
      * Reference resources
-->


[CHL-1013]: https://emnify.atlassian.net/browse/CHL-1013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ