### PR TITLE
Document how long event history is stored

### DIFF
--- a/docs/services/platform/events/index.md
+++ b/docs/services/platform/events/index.md
@@ -1,7 +1,7 @@
 ---
 description: Learn the basics and structure of emnify system events
 last_update: 
-  date: 01-03-2023
+  date: 02-21-2024
 pagination_next: services/platform/events/event-types
 slug: /system-events
 ---
@@ -10,6 +10,10 @@ slug: /system-events
 
 The emnify system generates several types of events.
 These events allow you to track notable system occurrences based on behavior and provide information about lifecycle transitions and configuration changes.
+
+:::info
+Event history is stored for 30 days.
+:::
 
 ## Use cases
 


### PR DESCRIPTION
<!--
  Thanks for making a pull request!
  Please make sure your title is as descriptive as possible. It's important for commit hisotry as we squash on merge and use the pull request title as the commit message.

  Have any questions?
  Feel free to ask in this PR or you can also send us an email: docs@emnify.com
-->

### Description

Adds an info block on the [Events getting started page](https://docs.emnify.com/system-events) specifying how long the event history is stored. I threw it in at the top of the page after the general description, but happy to move it if somewhere else makes more sense or it doesn't need to be so prominent.

<img width="607" alt="Screenshot 2024-02-21 at 09 54 31" src="https://github.com/emnify/product-docs/assets/26869552/e97d7ec1-7f80-4f97-9ea2-1d13d2460f4e">

> [!NOTE]
> This site only covers the emnify brand (and specifically enterprise customers), so we don't need to indicate any differences for channel partners. 

<!-- Write a brief description of the changes introduced by this PR -->

### Additional Context

Jira 🎟️ [CHL-1014](https://emnify.atlassian.net/browse/CHL-1014)

<!--
    Anything else that will help us better understand, for example:
      * Link(s) to the relevant issue or ticket
      * Screenshots
      * Reference resources
-->


[CHL-1014]: https://emnify.atlassian.net/browse/CHL-1014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ