### PR TITLE
Add SuperAdmin to the roles and permissions tables

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -570,7 +570,12 @@ User-defined limit of consumption for a certain service (data, SMS) per device.
 ## User account
 
 An account associated with a specific person and used to log in to one or more [workspaces](#workspace).
-User accounts can be assigned a role (for example, **Administrator**).
+User accounts can be assigned a role (for example, **Administrator**) per workspace.
+
+:::info
+A user can have different roles in different workspaces.
+For more information, see [Roles and permissions](/portal/roles).
+:::
 
 ## User-defined coverage
 

--- a/docs/portal/roles.mdx
+++ b/docs/portal/roles.mdx
@@ -26,57 +26,57 @@ The following tables describe the permissions for different roles.
 
 ## Device management
 
-| Action | Administrator | Observer | User |
-| ------ | :-----------: | :------: | :--: |
-| Retrieve a device by ID | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
-| Update or delete a device by ID | <Check alt="Yes" /> | <Close alt="No" /> | <Check alt="Yes" /> |
-| Retrieve the blocked networks for a device | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
-| Add or remove networks from the device blocklist by ID | <Check alt="Yes" /> | <Close alt="No" /> | <Check alt="Yes" /> |
-| List all devices | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
-| Create a new device | <Check alt="Yes" /> | <Close alt="No" /> | <Check alt="Yes" /> |
-| Retrieve connectivity information for a device | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
+| Action | SuperAdmin | Administrator | Observer | User |
+| ------ | :--------: | :-----------: | :------: | :--: |
+| Retrieve a device by ID | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
+| Update or delete a device by ID | <Check alt="Yes" /> | <Check alt="Yes" /> | <Close alt="No" /> | <Check alt="Yes" /> |
+| Retrieve the blocked networks for a device | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
+| Add or remove networks from the device blocklist by ID | <Check alt="Yes" /> | <Check alt="Yes" /> | <Close alt="No" /> | <Check alt="Yes" /> |
+| List all devices | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
+| Create a new device | <Check alt="Yes" /> | <Check alt="Yes" /> | <Close alt="No" /> | <Check alt="Yes" /> |
+| Retrieve connectivity information for a device | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
 
 ## SIM management
 
-| Action | Administrator | Observer | User |
-| ------ | :-----------: | :------: | :--: |
-| Retrieve SIMs by ID | <Check alt="✓" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
-| Update or delete SIMs by ID | <Check alt="Yes" /> | <Close alt="No" /> | <Check alt="Yes" /> |
-| List available SIM statuses | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
-| List available SIMs | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
+| Action | SuperAdmin | Administrator | Observer | User |
+| ------ | :--------: | :-----------: | :------: | :--: |
+| Retrieve SIMs by ID | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
+| Update or delete SIMs by ID | <Check alt="Yes" /> | <Check alt="Yes" /> | <Close alt="No" /> | <Check alt="Yes" /> |
+| List available SIM statuses | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
+| List available SIMs | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
 
-## Service profile
+## Service policy
 
-| Action | Administrator | Observer | User |
-| ------ | :-----------: | :------: | :--: |
-| Retrieve a list of available countries | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
-| Retrieve a list of available currencies | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
-| Retrieve single currency details by ID | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
-| Retrieve a list of available services | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
-| List available traffic limits for a service by ID | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
-| Retrieve service profiles | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
-| Create service profiles | <Check alt="Yes" /> | <Close alt="No" /> | <Check alt="Yes" /> |
-| Retrieve service profiles by ID | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
-| Update or delete service profiles by ID | <Check alt="Yes" /> | <Close alt="No" /> | <Check alt="Yes" /> |
-| Add or delete services from service profiles | <Check alt="Yes" /> | <Close alt="No" /> | <Check alt="Yes" /> |
-| Add or delete traffic limit from a service | <Check alt="Yes" /> | <Close alt="No" /> | <Check alt="Yes" /> |
-| Retrieve the ESME interface types | <Check alt="Yes" /> | <Close alt="No" /> | <Check alt="Yes" /> |
+| Action | SuperAdmin | Administrator | Observer | User |
+| ------ | :--------: | :-----------: | :------: | :--: |
+| Retrieve a list of available countries | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
+| Retrieve a list of available currencies | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
+| Retrieve single currency details by ID | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
+| Retrieve a list of available services | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
+| List available traffic limits for a service by ID | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
+| Retrieve service policies | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
+| Create service policies | <Check alt="Yes" /> | <Check alt="Yes" /> | <Close alt="No" /> | <Check alt="Yes" /> |
+| Retrieve service policies by ID | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
+| Update or delete service policies by ID | <Check alt="Yes" /> | <Check alt="Yes" /> | <Close alt="No" /> | <Check alt="Yes" /> |
+| Add or delete services from service policies | <Check alt="Yes" /> | <Check alt="Yes" /> | <Close alt="No" /> | <Check alt="Yes" /> |
+| Add or delete traffic limit from a service | <Check alt="Yes" /> | <Check alt="Yes" /> | <Close alt="No" /> | <Check alt="Yes" /> |
+| Retrieve the SMS interface types | <Check alt="Yes" /> | <Check alt="Yes" /> | <Close alt="No" /> | <Check alt="Yes" /> |
 
 ## Coverage policy
 
-| Action | Administrator | Observer | User |
-| ------ | :-----------: | :------: | :--: |
-| List of available coverage area statuses | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
-| List of available data plan statuses | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
-| Retrieve data plan details by ID | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
-| Retrieve data plans | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
-| Retrieve list of data plan statuses | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
-| Create coverage policies | <Check alt="Yes" /> | <Close alt="No" /> | <Check alt="Yes" /> |
-| List coverage policies | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
-| Retrieve coverage area of a coverage policy | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
-| Retrieve country details by ID | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
-| List networks | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
-| Retrieve my currently active data plan | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
+| Action | SuperAdmin | Administrator | Observer | User |
+| ------ | :--------: | :-----------: | :------: | :--: |
+| List of available coverage area statuses | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
+| List of available data plan statuses | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
+| Retrieve data plan details by ID | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
+| Retrieve data plans | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
+| Retrieve list of data plan statuses | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
+| Create coverage policies | <Check alt="Yes" /> | <Check alt="Yes" /> | <Close alt="No" /> | <Check alt="Yes" /> |
+| List coverage policies | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
+| Retrieve coverage area of a coverage policy | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
+| Retrieve country details by ID | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
+| List networks | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
+| Retrieve my currently active data plan | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
 
 ## User management
 
@@ -98,13 +98,6 @@ The following tables describe the permissions for different roles.
     </tr>
   </thead>
   <tbody>
-    <tr>
-      <td scope="row">Automatic access to all workspaces linked by emnify</td>
-      <td><Check alt="Yes" /></td>
-      <td><Close alt="No" /></td>
-      <td><Close alt="No" /></td>
-      <td><Close alt="No" /></td>
-    </tr>
     <tr>
       <td scope="row">Create or list workspace users</td>
       <td><Check alt="Yes" /></td>
@@ -178,23 +171,40 @@ The following tables describe the permissions for different roles.
   </tbody>
 </table>
 
+:::info
+A user can have different roles in different workspaces, even if they're linked.
+**SuperAdmin** is the only role that is consistent across linked workspaces by default.
+However, a user can be a SuperAdmin in one main organization but hold another role (for example, **Observer**) in an unrelated workspace with a different main organization.
+
+For more information, see [Multiple workspaces](/workspaces).
+:::
+
+## Workspace management
+
+| Action | SuperAdmin | Administrator | Observer | User |
+| ------ | :--------: | :-----------: | :------: | :--: |
+| Automatic access to all workspaces linked by emnify | <Check alt="Yes" /> | <Close alt="No" /> | <Close alt="No" /> | <Close alt="No" /> |
+| Create a new workspace   | <Check alt="Yes" /> | <Check alt="Yes" /> | <Close alt="No" /> | <Close alt="No" /> |
+| Link existing workspaces | <Check alt="Yes" /> | <Check alt="Yes" /> | <Close alt="No" /> | <Close alt="No" /> |
+| Switch between linked workspaces | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
+
 ## Alerts
 
-| Action | Administrator | Observer | User |
-| ------ | :-----------: | :------: | :--: |
-| Retrieve organization or device alerts | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
-| Retrieve user events by ID | <Check alt="Yes" /> | <Close alt="No" /> | <Close alt="No" /> |
-| Retrieve IMSI and SIM events | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
+| Action | SuperAdmin | Administrator | Observer | User |
+| ------ | :--------: | :-----------: | :------: | :--: |
+| Retrieve organization or device alerts | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
+| Retrieve user events by ID | <Check alt="Yes" /> | <Check alt="Yes" /> | <Close alt="No" /> | <Close alt="No" /> |
+| Retrieve IMSI and SIM events | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
 
 ## MFA keys
 
-| Action | Administrator | Observer | User |
-| ------ | :-----------: | :------: | :--: |
-| Generate user shared secret key for MFA | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
-| Activate user shared secret key for MFA | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
-| List available MFA key statuses | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
-| Delete shared secret key for MFA of a user by ID | <Check alt="Yes" /> | <Close alt="No" /> | <Close alt="No" /> |
-| List your trusted devices | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
-| Delete a trusted device from your list by ID | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
-| List available MFA key types | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
-| Delete my shared secret for MFA | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
+| Action | SuperAdmin | Administrator | Observer | User |
+| ------ | :--------: | :-----------: | :------: | :--: |
+| Generate user shared secret key for MFA | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
+| Activate user shared secret key for MFA | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
+| List available MFA key statuses | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
+| Delete shared secret key for MFA of a user by ID | <Check alt="Yes" /> | <Check alt="Yes" /> | <Close alt="No" /> | <Close alt="No" /> |
+| List your trusted devices | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
+| Delete a trusted device from your list by ID | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
+| List available MFA key types | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
+| Delete my shared secret for MFA | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |

--- a/docs/portal/roles.mdx
+++ b/docs/portal/roles.mdx
@@ -1,7 +1,7 @@
 ---
 description: Review the emnify account permissions for various roles
 last_update: 
-  date: 02-26-2024
+  date: 02-27-2024
 slug: /portal/roles
 ---
 
@@ -127,6 +127,13 @@ The following tables describe the permissions for different roles.
       <td><Check alt="Yes" /></td>
     </tr>
     <tr>
+      <td scope="row">Modify your user role</td>
+      <td><Close alt="No" /></td>
+      <td><Close alt="No" /></td>
+      <td><Close alt="No" /></td>
+      <td><Close alt="No" /></td>
+    </tr>
+    <tr>
       <td scope="row">Add or delete per workspace roles from a user</td>
       <td><Check alt="Yes" /></td>
       <td><Check alt="Yes" /></td>
@@ -183,10 +190,10 @@ For more information, see [Multiple workspaces](/workspaces).
 
 | Action | SuperAdmin | Administrator | Observer | User |
 | ------ | :--------: | :-----------: | :------: | :--: |
-| Automatic access to all workspaces linked by emnify | <Check alt="Yes" /> | <Close alt="No" /> | <Close alt="No" /> | <Close alt="No" /> |
-| Create a new workspace   | <Check alt="Yes" /> | <Check alt="Yes" /> | <Close alt="No" /> | <Close alt="No" /> |
-| Link existing workspaces | <Check alt="Yes" /> | <Check alt="Yes" /> | <Close alt="No" /> | <Close alt="No" /> |
-| Switch between linked workspaces | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
+| Automatically access to all workspaces linked to the main organization by emnify | <Check alt="Yes" /> | <Close alt="No" /> | <Close alt="No" /> | <Close alt="No" /> |
+| Send a request to create a new workspace   | <Check alt="Yes" /> | <Check alt="Yes" /> | <Close alt="No" /> | <Close alt="No" /> |
+| Send a request to link existing workspaces | <Check alt="Yes" /> | <Check alt="Yes" /> | <Close alt="No" /> | <Close alt="No" /> |
+| Switch between workspaces you have access to | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
 
 ## Alerts
 

--- a/docs/portal/roles.mdx
+++ b/docs/portal/roles.mdx
@@ -87,8 +87,8 @@ The following tables describe the permissions for different roles.
   <thead>
     <tr>
       <th rowSpan="2">Action</th>
-      <th colSpan="1" scope="colgroup">All workspaces</th>
-      <th colSpan="3" scope="colgroup">Per workspace</th>
+      <th colSpan="1" scope="colgroup">All Workspaces</th>
+      <th colSpan="3" scope="colgroup">Per Workspace</th>
     </tr>
     <tr>
       <th scope="col">SuperAdmin</th>
@@ -99,14 +99,14 @@ The following tables describe the permissions for different roles.
   </thead>
   <tbody>
     <tr>
-      <td scope="row">Create or list workspace users</td>
+      <td scope="row">Create or list Workspace users</td>
       <td><Check alt="Yes" /></td>
       <td><Check alt="Yes" /></td>
       <td><Close alt="No" /></td>
       <td><Close alt="No" /></td>
     </tr>
     <tr>
-      <td scope="row">Update or delete workspace users</td>
+      <td scope="row">Update or delete Workspace users</td>
       <td><Check alt="Yes" /></td>
       <td><Check alt="Yes" /></td>
       <td><Close alt="No" /></td>
@@ -134,7 +134,7 @@ The following tables describe the permissions for different roles.
       <td><Close alt="No" /></td>
     </tr>
     <tr>
-      <td scope="row">Add or delete per workspace roles from a user</td>
+      <td scope="row">Add or delete per Workspace roles from a user</td>
       <td><Check alt="Yes" /></td>
       <td><Check alt="Yes" /></td>
       <td><Close alt="No" /></td>
@@ -179,21 +179,21 @@ The following tables describe the permissions for different roles.
 </table>
 
 :::info
-A user can have different roles in different workspaces, even if they're linked.
-**SuperAdmin** is the only role that is consistent across linked workspaces by default.
-However, a user can be a SuperAdmin in one main organization but hold another role (for example, **Observer**) in an unrelated workspace with a different main organization.
+A user can have different roles in different Workspaces, even if they're linked.
+**SuperAdmin** is the only role that is consistent across linked Workspaces by default.
+However, a user can be a SuperAdmin in one main organization but hold another role (for example, **Observer**) in an unrelated Workspace with a different main organization.
 
-For more information, see [Multiple workspaces](/workspaces).
+For more information, see [Multiple Workspaces](/workspaces).
 :::
 
 ## Workspace management
 
 | Action | SuperAdmin | Administrator | Observer | User |
 | ------ | :--------: | :-----------: | :------: | :--: |
-| Automatically access to all workspaces linked to the main organization by emnify | <Check alt="Yes" /> | <Close alt="No" /> | <Close alt="No" /> | <Close alt="No" /> |
-| Send a request to create a new workspace   | <Check alt="Yes" /> | <Check alt="Yes" /> | <Close alt="No" /> | <Close alt="No" /> |
-| Send a request to link existing workspaces | <Check alt="Yes" /> | <Check alt="Yes" /> | <Close alt="No" /> | <Close alt="No" /> |
-| Switch between workspaces you have access to | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
+| Automatically access Workspaces linked to your organization by emnify | <Check alt="Yes" /> | <Close alt="No" /> | <Close alt="No" /> | <Close alt="No" /> |
+| Send a request to create a new Workspace   | <Check alt="Yes" /> | <Check alt="Yes" /> | <Close alt="No" /> | <Close alt="No" /> |
+| Send a request to link existing Workspaces | <Check alt="Yes" /> | <Check alt="Yes" /> | <Close alt="No" /> | <Close alt="No" /> |
+| Switch between Workspaces you have access to | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
 
 ## Alerts
 

--- a/docs/portal/roles.mdx
+++ b/docs/portal/roles.mdx
@@ -13,8 +13,9 @@ import Close from './assets/close.svg';
 The [emnify Portal](https://portal.emnify.com/) is a powerful application to control the connectivity of devices of a production system.
 
 Users across your Workspace may use the Portal, from operations and finance to development and product.
-That's why emnify offers three levels of access (referred to as **Roles**) to use and manage Portal features:
+That's why emnify offers four levels of access (referred to as **Roles**) to use and manage Portal features:
 
+- **SuperAdmin** (provided for organizations with [multiple workspaces](/workspaces))
 - **Administrator** (has access to all services and user management)
 - **Observer** (has access to limited services)
 - **User** (has access to all services)

--- a/docs/portal/roles.mdx
+++ b/docs/portal/roles.mdx
@@ -15,7 +15,7 @@ The [emnify Portal](https://portal.emnify.com/) is a powerful application to con
 Users across your Workspace may use the Portal, from operations and finance to development and product.
 That's why emnify offers four levels of access (referred to as **Roles**) to use and manage Portal features:
 
-- **SuperAdmin** (provided for organizations with [multiple workspaces](/workspaces))
+- **SuperAdmin** (provided for organizations with [multiple Workspaces](/workspaces))
 - **Administrator** (has access to all services and user management)
 - **Observer** (has access to limited services)
 - **User** (has access to all services)
@@ -190,7 +190,7 @@ For more information, see [Multiple Workspaces](/workspaces).
 
 | Action | SuperAdmin | Administrator | Observer | User |
 | ------ | :--------: | :-----------: | :------: | :--: |
-| Automatically access Workspaces linked to your organization by emnify | <Check alt="Yes" /> | <Close alt="No" /> | <Close alt="No" /> | <Close alt="No" /> |
+| Automatically access Workspaces linked to your main organization by emnify | <Check alt="Yes" /> | <Close alt="No" /> | <Close alt="No" /> | <Close alt="No" /> |
 | Send a request to create a new Workspace   | <Check alt="Yes" /> | <Check alt="Yes" /> | <Close alt="No" /> | <Close alt="No" /> |
 | Send a request to link existing Workspaces | <Check alt="Yes" /> | <Check alt="Yes" /> | <Close alt="No" /> | <Close alt="No" /> |
 | Switch between Workspaces you have access to | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |

--- a/docs/portal/roles.mdx
+++ b/docs/portal/roles.mdx
@@ -1,7 +1,7 @@
 ---
 description: Review the emnify account permissions for various roles
 last_update: 
-  date: 09-07-2023
+  date: 02-26-2024
 slug: /portal/roles
 ---
 
@@ -79,17 +79,96 @@ The following tables describe the permissions for different roles.
 
 ## User management
 
-| Action | Administrator | Observer | User |
-| ------ | :---: | :------: | :--: |
-| Create support token to assume permissions of a user by ID | <Close alt="No" /> | <Close alt="No" /> | <Close alt="No" /> |
-| Update or delete users | <Check alt="Yes" /> | <Close alt="No" /> | <Close alt="No" /> |
-| Retrieve my user role permissions | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
-| Update user password | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
-| Create or list users | <Check alt="Yes" /> | <Close alt="No" /> | <Close alt="No" /> |
-| Add or delete role from a user | <Check alt="Yes" /> | <Close alt="No" /> | <Close alt="No" /> |
-| Delete or list trusted devices for a given user | <Check alt="Yes" /> | <Close alt="No" /> | <Close alt="No" /> |
-| Create or retrieve an application token | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
-| Edit an application token | <Check alt="Yes" /> | <Close alt="No" /> | <Close alt="No" /> |
+<table>
+  <colgroup></colgroup>
+  <colgroup></colgroup>
+  <colgroup span="3"></colgroup>
+  <thead>
+    <tr>
+      <th rowSpan="2">Action</th>
+      <th colSpan="1" scope="colgroup">All workspaces</th>
+      <th colSpan="3" scope="colgroup">Per workspace</th>
+    </tr>
+    <tr>
+      <th scope="col">SuperAdmin</th>
+      <th scope="col">Administrator</th>
+      <th scope="col">Observer</th>
+      <th scope="col">User</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td scope="row">Access to all workspaces linked by emnify</td>
+      <td><Check alt="Yes" /></td>
+      <td><Close alt="No" /></td>
+      <td><Close alt="No" /></td>
+      <td><Close alt="No" /></td>
+    </tr>
+    <tr>
+      <td scope="row">Create support token to assume permissions of a user by ID</td>
+      <td><Close alt="No" /></td>
+      <td><Close alt="No" /></td>
+      <td><Close alt="No" /></td>
+      <td><Close alt="No" /></td>
+    </tr>
+    <tr>
+      <td scope="row">Update or delete users</td>
+      <td><Check alt="Yes" /></td>
+      <td><Check alt="Yes" /></td>
+      <td><Close alt="No" /></td>
+      <td><Close alt="No" /></td>
+    </tr>
+    <tr>
+      <td scope="row">Retrieve your user role permissions</td>
+      <td><Check alt="Yes" /></td>
+      <td><Check alt="Yes" /></td>
+      <td><Check alt="Yes" /></td>
+      <td><Check alt="Yes" /></td>
+    </tr>
+    <tr>
+      <td scope="row">Update your password</td>
+      <td><Check alt="Yes" /></td>
+      <td><Check alt="Yes" /></td>
+      <td><Check alt="Yes" /></td>
+      <td><Check alt="Yes" /></td>
+    </tr>
+    <tr>
+      <td scope="row">Create or list users</td>
+      <td><Check alt="Yes" /></td>
+      <td><Check alt="Yes" /></td>
+      <td><Close alt="No" /></td>
+      <td><Close alt="No" /></td>
+    </tr>
+    <tr>
+      <td scope="row">Add or delete roles from a user</td>
+      <td><Check alt="Yes" /></td>
+      <td><Check alt="Yes" /></td>
+      <td><Close alt="No" /></td>
+      <td><Close alt="No" /></td>
+    </tr>
+    <tr>
+      <td scope="row">Delete or list trusted devices for a given user</td>
+      <td><Check alt="Yes" /></td>
+      <td><Check alt="Yes" /></td>
+      <td><Close alt="No" /></td>
+      <td><Close alt="No" /></td>
+    </tr>
+    <tr>
+      <td scope="row">Create or retrieve an application token</td>
+      <td><Check alt="Yes" /></td>
+      <td><Check alt="Yes" /></td>
+      <td><Check alt="Yes" /></td>
+      <td><Check alt="Yes" /></td>
+    </tr>
+    <tr>
+      <td scope="row">Edit an application token</td>
+      <td><Check alt="Yes" /></td>
+      <td><Check alt="Yes" /></td>
+      <td><Close alt="No" /></td>
+      <td><Close alt="No" /></td>
+    </tr>
+  </tbody>
+</table>
 
 ## Alerts
 

--- a/docs/portal/roles.mdx
+++ b/docs/portal/roles.mdx
@@ -27,7 +27,7 @@ The following tables describe the permissions for different roles.
 ## Device management
 
 | Action | Administrator | Observer | User |
-| ------ | :---: | :------: | :--: |
+| ------ | :-----------: | :------: | :--: |
 | Retrieve a device by ID | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
 | Update or delete a device by ID | <Check alt="Yes" /> | <Close alt="No" /> | <Check alt="Yes" /> |
 | Retrieve the blocked networks for a device | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
@@ -39,7 +39,7 @@ The following tables describe the permissions for different roles.
 ## SIM management
 
 | Action | Administrator | Observer | User |
-| ------ | :---: | :------: | :--: |
+| ------ | :-----------: | :------: | :--: |
 | Retrieve SIMs by ID | <Check alt="✓" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
 | Update or delete SIMs by ID | <Check alt="Yes" /> | <Close alt="No" /> | <Check alt="Yes" /> |
 | List available SIM statuses | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
@@ -48,7 +48,7 @@ The following tables describe the permissions for different roles.
 ## Service profile
 
 | Action | Administrator | Observer | User |
-| ------ | :---: | :------: | :--: |
+| ------ | :-----------: | :------: | :--: |
 | Retrieve a list of available countries | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
 | Retrieve a list of available currencies | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
 | Retrieve single currency details by ID | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
@@ -65,7 +65,7 @@ The following tables describe the permissions for different roles.
 ## Coverage policy
 
 | Action | Administrator | Observer | User |
-| ------ | :---: | :------: | :--: |
+| ------ | :-----------: | :------: | :--: |
 | List of available coverage area statuses | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
 | List of available data plan statuses | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
 | Retrieve data plan details by ID | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
@@ -80,7 +80,7 @@ The following tables describe the permissions for different roles.
 
 ## User management
 
-<table>
+<table className="user-management-roles">
   <colgroup></colgroup>
   <colgroup></colgroup>
   <colgroup span="3"></colgroup>
@@ -99,32 +99,46 @@ The following tables describe the permissions for different roles.
   </thead>
   <tbody>
     <tr>
-      <td scope="row">Access to all workspaces linked by emnify</td>
+      <td scope="row">Automatic access to all workspaces linked by emnify</td>
       <td><Check alt="Yes" /></td>
       <td><Close alt="No" /></td>
       <td><Close alt="No" /></td>
       <td><Close alt="No" /></td>
     </tr>
     <tr>
-      <td scope="row">Create support token to assume permissions of a user by ID</td>
-      <td><Close alt="No" /></td>
-      <td><Close alt="No" /></td>
-      <td><Close alt="No" /></td>
-      <td><Close alt="No" /></td>
-    </tr>
-    <tr>
-      <td scope="row">Update or delete users</td>
+      <td scope="row">Create or list workspace users</td>
       <td><Check alt="Yes" /></td>
       <td><Check alt="Yes" /></td>
       <td><Close alt="No" /></td>
       <td><Close alt="No" /></td>
     </tr>
     <tr>
-      <td scope="row">Retrieve your user role permissions</td>
+      <td scope="row">Update or delete workspace users</td>
+      <td><Check alt="Yes" /></td>
+      <td><Check alt="Yes" /></td>
+      <td><Close alt="No" /></td>
+      <td><Close alt="No" /></td>
+    </tr>
+    <tr>
+      <td scope="row">Reassign or delete a SuperAdmin</td>
+      <td><Close alt="No" /></td>
+      <td><Close alt="No" /></td>
+      <td><Close alt="No" /></td>
+      <td><Close alt="No" /></td>
+    </tr>
+    <tr>
+      <td scope="row">Retrieve your user role</td>
       <td><Check alt="Yes" /></td>
       <td><Check alt="Yes" /></td>
       <td><Check alt="Yes" /></td>
       <td><Check alt="Yes" /></td>
+    </tr>
+    <tr>
+      <td scope="row">Add or delete per workspace roles from a user</td>
+      <td><Check alt="Yes" /></td>
+      <td><Check alt="Yes" /></td>
+      <td><Close alt="No" /></td>
+      <td><Close alt="No" /></td>
     </tr>
     <tr>
       <td scope="row">Update your password</td>
@@ -134,21 +148,7 @@ The following tables describe the permissions for different roles.
       <td><Check alt="Yes" /></td>
     </tr>
     <tr>
-      <td scope="row">Create or list users</td>
-      <td><Check alt="Yes" /></td>
-      <td><Check alt="Yes" /></td>
-      <td><Close alt="No" /></td>
-      <td><Close alt="No" /></td>
-    </tr>
-    <tr>
-      <td scope="row">Add or delete roles from a user</td>
-      <td><Check alt="Yes" /></td>
-      <td><Check alt="Yes" /></td>
-      <td><Close alt="No" /></td>
-      <td><Close alt="No" /></td>
-    </tr>
-    <tr>
-      <td scope="row">Delete or list trusted devices for a given user</td>
+      <td scope="row">Delete or list trusted devices for a user</td>
       <td><Check alt="Yes" /></td>
       <td><Check alt="Yes" /></td>
       <td><Close alt="No" /></td>
@@ -168,13 +168,20 @@ The following tables describe the permissions for different roles.
       <td><Close alt="No" /></td>
       <td><Close alt="No" /></td>
     </tr>
+    <tr>
+      <td scope="row">Create a support token to assume user permissions by ID</td>
+      <td><Close alt="No" /></td>
+      <td><Close alt="No" /></td>
+      <td><Close alt="No" /></td>
+      <td><Close alt="No" /></td>
+    </tr>
   </tbody>
 </table>
 
 ## Alerts
 
 | Action | Administrator | Observer | User |
-| ------ | :---: | :------: | :--: |
+| ------ | :-----------: | :------: | :--: |
 | Retrieve organization or device alerts | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
 | Retrieve user events by ID | <Check alt="Yes" /> | <Close alt="No" /> | <Close alt="No" /> |
 | Retrieve IMSI and SIM events | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
@@ -182,7 +189,7 @@ The following tables describe the permissions for different roles.
 ## MFA keys
 
 | Action | Administrator | Observer | User |
-| ------ | :---: | :------: | :--: |
+| ------ | :-----------: | :------: | :--: |
 | Generate user shared secret key for MFA | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
 | Activate user shared secret key for MFA | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |
 | List available MFA key statuses | <Check alt="Yes" /> | <Check alt="Yes" /> | <Check alt="Yes" /> |

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -144,6 +144,7 @@ _________________
   border: none !important;
 }
 
+/* Center SVG icons in tables built with HTML tables */
 table.user-management-roles tr td:not(:first-child) {
   text-align: center;
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -144,6 +144,10 @@ _________________
   border: none !important;
 }
 
+table.user-management-roles tr td:not(:first-child) {
+  text-align: center;
+}
+
 /* Inline code elements wrapped in an anchor tag */
 a:has(> code) {
   text-decoration: none;


### PR DESCRIPTION
### Description

Follows #294 👯 

Currently, there's no mention of the SuperAdmin on the [Roles and permissions](https://docs.emnify.com/portal/roles) tables. This PR changes that and also includes...

- Refactoring the "User management" table to distinguish cross-workspace vs per workspace roles
  - Built in HTML to retain a11y standards for [tables with irregular headers](https://www.w3.org/WAI/tutorials/tables/irregular/)
- Adding any new or previously missing actions to the "User management" table
- Quickly updating the former "Service profile" table to match "Service policy" terminology
- Creating a "Workspace management" table with associated permissions

<!-- Write a brief description of the changes introduced by this PR -->

### Additional Context

Internal 🎟️ [DOCS-400](https://emnify.atlassian.net/browse/DOCS-400) (parent task: [DOCS-396](https://emnify.atlassian.net/browse/DOCS-396))

<!--
    Anything else that will help us better understand, for example:
      * Link(s) to the relevant issue or ticket
      * Screenshots
      * Reference resources
-->


[DOCS-396]: https://emnify.atlassian.net/browse/DOCS-396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DOCS-400]: https://emnify.atlassian.net/browse/DOCS-400?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ